### PR TITLE
DDCE-984:Remove H2 from confirmation page in all address lookups

### DIFF
--- a/app/models/addressLookup/AddressLookupLanguageModel.scala
+++ b/app/models/addressLookup/AddressLookupLanguageModel.scala
@@ -156,7 +156,7 @@ object ConfirmPageMessagesModel {
       title = MessageOption(s"$messagePrefix.confirmPage.title", lang),
       heading = MessageOption(s"$messagePrefix.confirmPage.heading", lang, fullName.getOrElse("")),
       infoMessage = Some(""),
-      infoSubheading = MessageOption(s"$messagePrefix..confirmPage.infoSubheading", lang, fullName.getOrElse("")),
+      infoSubheading = Some(""),
       submitLabel = MessageOption(s"commonAddress.confirmPage.submitLabel", lang),
       searchAgainLinkText = MessageOption(s"commonAddress.confirmPage.searchAgainLinkText", lang),
       changeLinkText = MessageOption(s"$messagePrefix.confirmPage.changeLinkText", lang, fullName.getOrElse("")),


### PR DESCRIPTION
# DDCE-984:Remove H2 from confirmation page in all address lookups

## New feature 

Remove H2 from confirmation page in all address lookups

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

## Checklist PR Reviewer
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [x]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
