### PR TITLE
[RS][DDCE-1095] Fixed parsing bug for dates far in the past.

### DIFF
--- a/app/utils/ImplicitDateFormatter.scala
+++ b/app/utils/ImplicitDateFormatter.scala
@@ -20,18 +20,23 @@ import java.time.LocalDate
 
 import com.ibm.icu.text.SimpleDateFormat
 import com.ibm.icu.util.{TimeZone, ULocale}
-import org.joda.time.{MonthDay, LocalDate => JLocalDate}
+import org.joda.time.MonthDay
 import play.api.i18n.Messages
 
 import scala.language.implicitConversions
 
 trait ImplicitDateFormatter {
-
+  private val midday: Int = 12
   implicit def dateToString(date:LocalDate)(implicit messages: Messages): String = createDateFormatForPattern(
-    "d MMMM yyyy").format(new JLocalDate(date.getYear, date.getMonthValue, date.getDayOfMonth).toDate)
+    "d MMMM yyyy").format {
+    new SimpleDateFormat("yyyy-MM-dd'T'HH")
+      .parse(date.atTime(midday, 0).toString)
+  }
 
   implicit def monthToString(monthDay: MonthDay)(implicit messages: Messages): String = createDateFormatForPattern(
-    "d MMMM").format(new JLocalDate(LocalDate.now().getYear, monthDay.getMonthOfYear, monthDay.getDayOfMonth).toDate)
+    "d MMMM").format(
+    new SimpleDateFormat("yyyy-MM-dd").parse(monthDay.toLocalDate(LocalDate.now().getYear).toString)
+  )
 
   def dayToString(date:LocalDate)(implicit messages: Messages): String =
   {
@@ -42,7 +47,10 @@ trait ImplicitDateFormatter {
       case 3 =>  "rd"
       case _ =>  "th"
     }
-    createDateFormatForPattern(s"EEEE d'$dateSuffix' MMMM yyyy").format(new JLocalDate(date.getYear, date.getMonthValue, date.getDayOfMonth).toDate)
+    createDateFormatForPattern(
+      s"EEEE d'$dateSuffix' MMMM yyyy").format(
+        new SimpleDateFormat("yyyy-MM-dd").parse(date.toString)
+      )
 
   }
 

--- a/test/utils/ImplicitDateFormatterSpec.scala
+++ b/test/utils/ImplicitDateFormatterSpec.scala
@@ -37,6 +37,10 @@ class ImplicitDateFormatterSpec extends SpecBase with ImplicitDateFormatter {
       dateToString(LocalDate.of(2017, 4, 1)) mustBe result
     }
 
+    "format dates far in the past in the correct style" in {
+      val result: String = "1 January 1111"
+      dateToString(LocalDate.of(1111, 1, 1)) mustBe result
+    }
     "format months with single digit values in correct style" in {
       val result: String = "30 June 2017"
       dateToString(LocalDate.of(2017, 6, 30)) mustBe result


### PR DESCRIPTION
# DDCE-1095

## Bug fix 

Using Joda LocalDate.toDate() results in a date that can be off-by-one due to DST parsing in IBM's SimpleDateFormat. This is averted by using SimpleDateFormat.parse() instead to obtain the Date objects.

## PR Suggestions
- Have you looked at the JIRA story to make sure all Acceptance Criteria has been met?
- Have you done a visual check of the changes?
- Is there any still commented or unused code? Lingering printlns?
- Have things been implemented in a complicated way?
- Are the test still over the coverage threshold?
- Does the compiler throw a lot of warnings? 
- Have methods and tests been named clearly?
- Were there any changes in the config? Do changes need to be made in app-config-???


## Checklist PR Raiser
 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
