### PR TITLE
DDCE 3292 : Charity Object Validation

### DIFF
--- a/app/connectors/CharitiesShortLivedCache.scala
+++ b/app/connectors/CharitiesShortLivedCache.scala
@@ -34,6 +34,5 @@ class CharitiesShortLivedCache @Inject() (
   val shortLiveCache: CharitiesShortLivedHttpCaching,
   applicationCrypto: ApplicationCrypto
 ) extends ShortLivedCache {
-
   override implicit lazy val crypto: CompositeSymmetricCrypto = applicationCrypto.JsonCrypto
 }

--- a/app/forms/mappings/Mappings.scala
+++ b/app/forms/mappings/Mappings.scala
@@ -25,9 +25,9 @@ import play.api.data.Forms.of
 
 trait Mappings extends Formatters with Constraints {
 
-  val validateField             = "^[a-zA-Z0-9-, ']+$"
-  val validateFieldWithFullStop = "^[a-zA-Z0-9-, '.]+$"
-  val validateFieldWithNewLine  = "^[a-zA-Z0-9-, '.\n\r\t]+$"
+  val validateField             = "^[a-zA-Z0-9-, '’]+$"
+  val validateFieldWithFullStop = "^[a-zA-Z0-9-, '’.]+$"
+  val validateFieldWithNewLine  = "^[a-zA-Z0-9-, '’.\n\r\t]+$"
   val validateTelephoneNumber   = """^\+?(?:\s*\d){10,13}$"""
   val validateEmailExtraTld     = """^.*(@([0-9]+.)+)$"""
   // scalastyle:off line.size.limit

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,7 +4,7 @@ object AppDependencies {
 
   import play.core.PlayVersion
 
-  private lazy val mongoHmrcVersion = "0.71.0"
+  private lazy val mongoHmrcVersion = "0.73.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
@@ -12,7 +12,7 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "logback-json-logger"           % "5.2.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.11.0-play-28",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % "6.4.0",
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.24.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "3.29.0-play-28",
     "uk.gov.hmrc"       %% "play-language"                 % "5.3.0-play-28",
     "uk.gov.hmrc"       %% "http-caching-client"           % "9.6.0-play-28",
     "uk.gov.hmrc"       %% "play-allowlist-filter"         % "1.1.0",
@@ -21,12 +21,12 @@ object AppDependencies {
 
   val test: Seq[ModuleID]    = Seq(
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"     % mongoHmrcVersion,
-    "org.scalatest"          %% "scalatest"                   % "3.2.13",
+    "org.scalatest"          %% "scalatest"                   % "3.2.14",
     "org.scalatestplus.play" %% "scalatestplus-play"          % "5.1.0",
     "org.jsoup"               % "jsoup"                       % "1.15.3",
     "com.typesafe.play"      %% "play-test"                   % PlayVersion.current,
     "org.mockito"             % "mockito-core"                % "4.8.0",
-    "org.scalacheck"         %% "scalacheck"                  % "1.16.0",
+    "org.scalacheck"         %% "scalacheck"                  % "1.17.0",
     "org.scalamock"          %% "scalamock-scalatest-support" % "3.6.0",
     "com.github.tomakehurst"  % "wiremock-standalone"         % "2.27.2",
     "org.scalatestplus"      %% "mockito-3-4"                 % "3.2.10.0",

--- a/test/controllers/regulatorsAndDocuments/RegulatorsSummaryControllerSpec.scala
+++ b/test/controllers/regulatorsAndDocuments/RegulatorsSummaryControllerSpec.scala
@@ -18,16 +18,13 @@ package controllers.regulatorsAndDocuments
 
 import base.SpecBase
 import controllers.actions.{AuthIdentifierAction, FakeAuthIdentifierAction}
-import models.{CharityOtherRegulatorDetails, UserAnswers}
-import models.regulators.CharityRegulator
-import models.regulators.CharityRegulator.{EnglandWales, NorthernIreland, Other, Scottish}
-import models.regulators.SelectWhyNoRegulator.EnglandWalesUnderThreshold
+import models.UserAnswers
 import navigation.FakeNavigators.FakeRegulatorsAndDocumentsNavigator
 import navigation.RegulatorsAndDocumentsNavigator
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, _}
 import org.scalatest.BeforeAndAfterEach
-import pages.regulatorsAndDocuments.{CharityCommissionRegistrationNumberPage, CharityOtherRegulatorDetailsPage, CharityRegulatorPage, IsCharityRegulatorPage, NIRegulatorRegNumberPage, ScottishRegulatorRegNumberPage, SelectWhyNoRegulatorPage, WhyNotRegisteredWithCharityPage}
+import pages.regulatorsAndDocuments.IsCharityRegulatorPage
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers.{redirectLocation, status, _}

--- a/test/pages/operationsAndFunds/AccountingPeriodEndDatePageSpec.scala
+++ b/test/pages/operationsAndFunds/AccountingPeriodEndDatePageSpec.scala
@@ -28,7 +28,7 @@ class AccountingPeriodEndDatePageSpec extends PageBehaviours {
   val dayInMonth = 1
 
   implicit lazy val arbitraryLocalDate: Arbitrary[MonthDay] = Arbitrary {
-    MonthDay.fromDateFields(new LocalDate(2020, month, 1).toDate)
+    MonthDay.fromDateFields(new LocalDate(year, month, dayInMonth).toDate)
   }
 
   "AccountingPeriodEndDate" must {

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -20,7 +20,7 @@ import models.oldCharities.{Acknowledgement, _}
 import org.joda.time.{LocalDate, MonthDay}
 
 trait TestData {
-
+  // scalastyle:off magic.number
   val contactDetails: CharityContactDetails                                     = CharityContactDetails("Test123", None, "1234567890", None, None, None)
   val charityAddress: CharityAddress                                            = CharityAddress("Test123", "line2", "", "", "postcode", "")
   val correspondenceAddress: OptionalCharityAddress                             =
@@ -350,5 +350,5 @@ trait TestData {
     )
   )
   val acknowledgement: Acknowledgement                                          = Acknowledgement("080582080582", "9:56am, Tuesday 1 December 2020")
-
+  // scalastyle:on magic.number
 }

--- a/test/views/RegistrationSentViewSpec.scala
+++ b/test/views/RegistrationSentViewSpec.scala
@@ -26,13 +26,14 @@ class RegistrationSentViewSpec extends ViewBehaviours with ImplicitDateFormatter
   private val messageKeyPrefix         = "registrationSent"
   private val section: Option[String]  = Some(messages("declaration.section"))
   private val firstLinkContent: String = "javascript:window.print()"
+  private val registrationExpiryLimit  = 28
 
   "RegistrationSentView for Email" must {
 
     def applyView(): HtmlFormat.Appendable = {
       val view = viewFor[RegistrationSentView](Some(emptyUserAnswers))
       view.apply(
-        dayToString(inject[TimeMachine].now().plusDays(28)),
+        dayToString(inject[TimeMachine].now().plusDays(registrationExpiryLimit)),
         dayToString(inject[TimeMachine].now()),
         "080582080582",
         emailOrPost = true,
@@ -89,7 +90,7 @@ class RegistrationSentViewSpec extends ViewBehaviours with ImplicitDateFormatter
     def applyView(): HtmlFormat.Appendable = {
       val view = viewFor[RegistrationSentView](Some(emptyUserAnswers))
       view.apply(
-        dayToString(inject[TimeMachine].now().plusDays(28)),
+        dayToString(inject[TimeMachine].now().plusDays(registrationExpiryLimit)),
         dayToString(inject[TimeMachine].now()),
         "080582080582",
         emailOrPost = false,
@@ -149,7 +150,7 @@ class RegistrationSentViewSpec extends ViewBehaviours with ImplicitDateFormatter
     def applyView(): HtmlFormat.Appendable = {
       val view = viewFor[RegistrationSentView](Some(emptyUserAnswers))
       view.apply(
-        dayToString(inject[TimeMachine].now().plusDays(28)),
+        dayToString(inject[TimeMachine].now().plusDays(registrationExpiryLimit)),
         dayToString(inject[TimeMachine].now()),
         "080582080582",
         emailOrPost = true,

--- a/test/views/behaviours/IntViewBehaviours.scala
+++ b/test/views/behaviours/IntViewBehaviours.scala
@@ -31,48 +31,38 @@ trait IntViewBehaviours extends QuestionViewBehaviours[Int] {
     section: Option[String] = None
   ): Unit =
     "behave like a page with an integer value field" when {
-
       "rendered" must {
-
         "contain a label for the value" in {
-
           val doc = asDocument(createView(form))
           assertContainsLabel(doc, "value", messages(s"$messageKeyPrefix.label"))
         }
 
         "contain an input for the value" in {
-
           val doc = asDocument(createView(form))
           assertRenderedById(doc, "value")
         }
       }
 
       "rendered with a valid form" must {
-
         "include the form's value in the value input" in {
-
           val doc = asDocument(createView(form.fill(number)))
           doc.getElementById("value").attr("value") mustBe number.toString
         }
       }
 
       "rendered with an error" must {
-
         "show an error summary" in {
-
           val doc = asDocument(createView(form.withError(error)))
           assertRenderedById(doc, "error-summary-title")
         }
 
         "show an error associated with the value field" in {
-
           val doc       = asDocument(createView(form.withError(error)))
           val errorSpan = doc.getElementsByClass("govuk-error-message").first
           errorSpan.text mustBe (messages("error.browser.title.prefix") + " " + messages(errorMessage))
         }
 
         "show an error prefix in the browser title" in {
-
           val doc = asDocument(createView(form.withError(error)))
           assertEqualsValue(
             doc,


### PR DESCRIPTION
## DDCE-3292

- Updated validation on input fields in the registration where the user may have used `’` as an apostrophe as opposed to previously only `'` being allowed.
- Checked that ETMP accepts anything submitted as an escaped string
- Design agrees to allow the user to do this.
- Updated possible dependencies excluding `bootstrap-frontend-play-28` due to CharitiesShortLivedCache relying on deprecated crypto.

 - [x]  Manually tested functionality
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've run a dependency check to ensure all dependencies are up to date
