### PR TITLE
DDCE-3836: Allow users to type in international phone numbers

### DIFF
--- a/app/forms/mappings/Mappings.scala
+++ b/app/forms/mappings/Mappings.scala
@@ -28,7 +28,7 @@ trait Mappings extends Formatters with Constraints {
   val validateField             = "^[a-zA-Z0-9-, '’]+$"
   val validateFieldWithFullStop = "^[a-zA-Z0-9-, '’.]+$"
   val validateFieldWithNewLine  = "^[a-zA-Z0-9-, '’.\n\r\t]+$"
-  val validateTelephoneNumber   = """^\+?(?:\s*\d){10,13}$"""
+  val validateTelephoneNumber   = """^\+?(?:\s*\d){10,20}$"""
   val validateEmailExtraTld     = """^.*(@([0-9]+.)+)$"""
   // scalastyle:off line.size.limit
   val validateEmailAddress      =

--- a/app/views/common/PhoneNumberView.scala.html
+++ b/app/views/common/PhoneNumberView.scala.html
@@ -45,6 +45,7 @@
                 label = s"$messagePrefix.mainPhoneNumber.label",
                 isPageHeading = false,
                 classes = Some("govuk-input govuk-!-width-one-half"),
+                hint = Some(Html(messages(s"$messagePrefix.mainPhoneNumber.hint"))),
                 inputType = "tel",
                 isTelephone = true
             )
@@ -56,6 +57,7 @@
                 label = s"$messagePrefix.alternativePhoneNumber.label",
                 isPageHeading = false,
                 classes = Some("govuk-input govuk-!-width-one-half"),
+                hint = Some(Html(messages(s"$messagePrefix.alternativePhoneNumber.hint"))),
                 inputType = "tel",
                 isTelephone = true
             )

--- a/app/views/contactDetails/CharityContactDetailsView.scala.html
+++ b/app/views/contactDetails/CharityContactDetailsView.scala.html
@@ -47,6 +47,7 @@
                 id = "mainPhoneNumber",
                 name = "mainPhoneNumber",
                 label = "charityContactDetails.mainPhoneNumber.label",
+                hint = Some(Html(messages("charityContactDetails.mainPhoneNumber.hint"))),
                 isPageHeading = false,
                 classes = Some("govuk-input govuk-!-width-one-half")
             )
@@ -56,6 +57,7 @@
                 id = "alternativePhoneNumber",
                 name = "alternativePhoneNumber",
                 label = "charityContactDetails.alternativePhoneNumber.label",
+                hint = Some(Html(messages("charityContactDetails.alternativePhoneNumber.hint"))),
                 isPageHeading = false,
                 classes = Some("govuk-input govuk-!-width-one-half")
             )

--- a/app/views/nominees/OrganisationNomineeContactDetailsView.scala.html
+++ b/app/views/nominees/OrganisationNomineeContactDetailsView.scala.html
@@ -44,6 +44,7 @@
     name = "phoneNumber",
     label = "organisationContactDetails.phoneNumber.label",
     isPageHeading = false,
+    hint = Some(Html(messages("organisationContactDetails.phoneNumber.hint"))),
     classes = Some("govuk-input govuk-input--width-20"),
     inputType = "tel",
     isTelephone = true

--- a/build.sbt
+++ b/build.sbt
@@ -48,7 +48,7 @@ lazy val root = (project in file("."))
       ".*models.Mode*;.*handlers.*;.*components.*;.*TimeMachine.*;" +
       ".*BuildInfo.*;.*javascript.*;.*FrontendAuditConnector.*;.*Routes.*;.*GuiceInjector;" +
       ".*ControllerConfiguration;.*testonly.*;",
-    ScoverageKeys.coverageMinimumStmtTotal := 80,
+    ScoverageKeys.coverageMinimumStmtTotal := 98,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true,
     scalacOptions ++= Seq("-feature", "-Xlint:-unused", "-Wconf:src=routes/.*:s,src=views/.*:s"),

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -442,17 +442,22 @@ charityName.operatingName.checkYourAnswersLabel = Enw gweithredol
 # ----------------------------------------------------------
 charityContactDetails.title = Manylion cyswllt yr elusen
 charityContactDetails.heading = Manylion cyswllt yr elusen
+
 charityContactDetails.mainPhoneNumber.label = Prif rif ffôn
-charityContactDetails.mainPhoneNumber.error.format = Nodwch brif rif ffôn yr elusen, megis 01632 960 001
+charityContactDetails.mainPhoneNumber.error.format = Nodwch brif rif ffôn yr elusen, megis 01632 960 001, 07700 900 982 neu +44 808 157 0192
 charityContactDetails.mainPhoneNumber.error.required = Nodwch brif rif ffôn yr elusen
+charityContactDetails.mainPhoneNumber.hint = Ar gyfer rhifau rhyngwladol, cofiwch gynnwys cod y wlad
+charityContactDetails.mainPhoneNumber.checkYourAnswersLabel = Prif rif ffôn
+
 charityContactDetails.alternativePhoneNumber.label = Rhif ffôn arall (dewisol)
-charityContactDetails.alternativePhoneNumber.error.format = Nodwch brif rif ffôn arall yr elusen, megis 01632 960 001
+charityContactDetails.alternativePhoneNumber.error.format = Nodwch rif ffôn arall yr elusen, megis 01632 960 001, 07700 900 982 neu +44 808 157 0192
+charityContactDetails.alternativePhoneNumber.hint = Ar gyfer rhifau rhyngwladol, cofiwch gynnwys cod y wlad
+charityContactDetails.alternativePhoneNumber.checkYourAnswersLabel = Rhif ffôn arall
+
 charityContactDetails.emailAddress.label = Cyfeiriad e-bost
 charityContactDetails.emailAddress.error.required = Nodwch gyfeiriad e-bost yr elusen
 charityContactDetails.emailAddress.error.format = Nodwch gyfeiriad e-bost yr elusen yn y fformat cywir, fel enw@enghraifft.com
 charityContactDetails.emailAddress.error.length = Mae’n rhaid i’r cyfeiriad e-bost fod yn 160 o gymeriadau neu lai
-charityContactDetails.mainPhoneNumber.checkYourAnswersLabel = Prif rif ffôn
-charityContactDetails.alternativePhoneNumber.checkYourAnswersLabel = Rhif ffôn arall
 charityContactDetails.emailAddress.checkYourAnswersLabel = Cyfeiriad e-bost
 
 # Charity Official Address Messages
@@ -1075,13 +1080,15 @@ authorisedOfficialsDOB.checkYourAnswersLabel = Dyddiad geni
 authorisedOfficialsPhoneNumber.title = Rhifau ffôn y swyddog awdurdodedig
 authorisedOfficialsPhoneNumber.heading = Rhifau ffôn {0}
 authorisedOfficialsPhoneNumber.mainPhoneNumber.label = Prif rif ffôn
-authorisedOfficialsPhoneNumber.mainPhoneNumber.error.format = Nodwch ei brif rif ffôn, megis 01632 960 001
+authorisedOfficialsPhoneNumber.mainPhoneNumber.error.format = Nodwch brif rif ffôn y swyddog awdurdodedig, megis 01632 960 001, 07700 900 982 neu +44 808 157 0192
 authorisedOfficialsPhoneNumber.mainPhoneNumber.error.required = Nodwch ei brif rif ffôn
+authorisedOfficialsPhoneNumber.mainPhoneNumber.hint = Ar gyfer rhifau rhyngwladol, cofiwch gynnwys cod y wlad
+
 authorisedOfficialsPhoneNumber.alternativePhoneNumber.label = Rhif ffôn arall (dewisol)
-authorisedOfficialsPhoneNumber.alternativePhoneNumber.error.format = Nodwch ei rif ffôn arall, megis 01632 960 001
+authorisedOfficialsPhoneNumber.alternativePhoneNumber.error.format = Nodwch rif ffôn arall y swyddog awdurdodedig, megis 01632 960 001, 07700 900 982 neu +44 808 157 0192
 authorisedOfficialsPhoneNumber.mainPhoneNumber.checkYourAnswersLabel = Prif rif ffôn
 authorisedOfficialsPhoneNumber.alternativePhoneNumber.checkYourAnswersLabel = Rhif ffôn arall
-
+authorisedOfficialsPhoneNumber.alternativePhoneNumber.hint = Ar gyfer rhifau rhyngwladol, cofiwch gynnwys cod y wlad
 authorisedOfficialsPhoneNumber.checkYourAnswersLabel = Rhif ffôn
 
 # Authorised Official Position  Messages
@@ -1291,12 +1298,15 @@ otherOfficialsDOB.checkYourAnswersLabel = Dyddiad geni
 otherOfficialsPhoneNumber.title = Rhifau ffôn y swyddog arall
 otherOfficialsPhoneNumber.heading = Rhifau ffôn {0}
 otherOfficialsPhoneNumber.mainPhoneNumber.label = Prif rif ffôn
-otherOfficialsPhoneNumber.mainPhoneNumber.error.format = Nodwch ei brif rif ffôn, megis 01632 960 001
+otherOfficialsPhoneNumber.mainPhoneNumber.error.format = Nodwch brif rif ffôn y swyddog, megis 01632 960 001, 07700 900 982 neu +44 808 157 0192
 otherOfficialsPhoneNumber.mainPhoneNumber.error.required = Nodwch ei brif rif ffôn
+otherOfficialsPhoneNumber.mainPhoneNumber.hint = Ar gyfer rhifau rhyngwladol, cofiwch gynnwys cod y wlad
+
 otherOfficialsPhoneNumber.alternativePhoneNumber.label = Rhif ffôn arall (dewisol)
-otherOfficialsPhoneNumber.alternativePhoneNumber.error.format = Nodwch ei rif ffôn arall, megis 01632 960 001
+otherOfficialsPhoneNumber.alternativePhoneNumber.error.format = Nodwch rif ffôn arall y swyddog, megis 01632 960 001, 07700 900 982 neu +44 808 157 0192
 otherOfficialsPhoneNumber.mainPhoneNumber.checkYourAnswersLabel = Prif rif ffôn
 otherOfficialsPhoneNumber.alternativePhoneNumber.checkYourAnswersLabel = Rhif ffôn arall
+otherOfficialsPhoneNumber.alternativePhoneNumber.hint = Ar gyfer rhifau rhyngwladol, cofiwch gynnwys cod y wlad
 
 otherOfficialsPhoneNumber.checkYourAnswersLabel = Rhif ffôn
 
@@ -1519,12 +1529,14 @@ individualNomineeDOB.checkYourAnswersLabel = Dyddiad geni
 individualNomineesPhoneNumber.title = Rhifau ffôn yr enwebai
 individualNomineesPhoneNumber.heading = Rhifau ffôn {0}
 individualNomineesPhoneNumber.mainPhoneNumber.label = Prif rif ffôn
-individualNomineesPhoneNumber.mainPhoneNumber.error.format = Nodwch ei brif rif ffôn, megis 01632 960 001
+individualNomineesPhoneNumber.mainPhoneNumber.error.format = Nodwch brif rif ffôn yr enwebai, megis 01632 960 001, 07700 900 982 neu +44 808 157 0192
 individualNomineesPhoneNumber.mainPhoneNumber.error.required = Nodwch ei brif rif ffôn
-individualNomineesPhoneNumber.alternativePhoneNumber.label = Rhif ffôn arall (dewisol)
-individualNomineesPhoneNumber.alternativePhoneNumber.error.format = Nodwch ei rif ffôn arall, fel 01632 960 001, 07700 900 982 neu +44 0808 157 019
-individualNomineesPhoneNumber.alternativePhoneNumber.error.required = Nodwch ei rif ffôn arall
+individualNomineesPhoneNumber.mainPhoneNumber.hint = Ar gyfer rhifau rhyngwladol, cofiwch gynnwys cod y wlad
 
+individualNomineesPhoneNumber.alternativePhoneNumber.label = Rhif ffôn arall (dewisol)
+individualNomineesPhoneNumber.alternativePhoneNumber.error.format = Nodwch rif ffôn arall yr enwebai, megis 01632 960 001, 07700 900 982 neu +44 808 157 0192
+individualNomineesPhoneNumber.alternativePhoneNumber.error.required = Nodwch ei rif ffôn arall
+individualNomineesPhoneNumber.alternativePhoneNumber.hint = Ar gyfer rhifau rhyngwladol, cofiwch gynnwys cod y wlad
 individualNomineesPhoneNumber.mainPhoneNumber.checkYourAnswersLabel = Prif rif ffôn
 individualNomineesPhoneNumber.alternativePhoneNumber.checkYourAnswersLabel = Rhif ffôn arall
 
@@ -1677,7 +1689,8 @@ nameOfOrganisation.checkYourAnswersLabel = Enw
 organisationContactDetails.title = Manylion cyswllt sefydliad yr enwebai
 organisationContactDetails.heading = Manylion cyswllt {0}
 organisationContactDetails.phoneNumber.label = Rhif ffôn
-organisationContactDetails.phoneNumber.error.format = Nodwch brif rif ffôn y sefydliad, megis 01632 960 001
+organisationContactDetails.phoneNumber.hint = Ar gyfer rhifau rhyngwladol, cofiwch gynnwys cod y wlad
+organisationContactDetails.phoneNumber.error.format = Nodwch rif ffôn y sefydliad, megis 01632 960 001, 07700 900 982 neu +44 808 157 0192
 organisationContactDetails.phoneNumber.error.required = Nodwch rif ffôn y sefydliad
 organisationContactDetails.email.label = Cyfeiriad e-bost
 organisationContactDetails.email.error.format = Nodwch y cyfeiriad e-bost yn y fformat cywir, fel enw@enghraifft.com

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -443,16 +443,18 @@ charityName.operatingName.checkYourAnswersLabel = Operating name
 charityContactDetails.title = The charity’s contact details
 charityContactDetails.heading = The charity’s contact details
 charityContactDetails.mainPhoneNumber.label = Main phone number
-charityContactDetails.mainPhoneNumber.error.format = Enter the charity’s main phone number, like 01632 960 001
+charityContactDetails.mainPhoneNumber.error.format = Enter the charity’s main phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 charityContactDetails.mainPhoneNumber.error.required = Enter the charity’s main phone number
+charityContactDetails.mainPhoneNumber.hint = For international numbers include the country code
+charityContactDetails.mainPhoneNumber.checkYourAnswersLabel = Main phone number
 charityContactDetails.alternativePhoneNumber.label = Alternative phone number (optional)
-charityContactDetails.alternativePhoneNumber.error.format = Enter the charity’s alternative phone number, like 01632 960 001
+charityContactDetails.alternativePhoneNumber.error.format = Enter the charity’s alternative phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
+charityContactDetails.alternativePhoneNumber.hint = For international numbers include the country code
+charityContactDetails.alternativePhoneNumber.checkYourAnswersLabel = Alternative phone number
 charityContactDetails.emailAddress.label = Email address
 charityContactDetails.emailAddress.error.required = Enter the charity’s email address
 charityContactDetails.emailAddress.error.format = Enter the charity’s email address in the correct format, like name@example.com
 charityContactDetails.emailAddress.error.length = Email address must be 160 characters or less
-charityContactDetails.mainPhoneNumber.checkYourAnswersLabel = Main phone number
-charityContactDetails.alternativePhoneNumber.checkYourAnswersLabel = Alternative phone number
 charityContactDetails.emailAddress.checkYourAnswersLabel = Email address
 
 # Charity Official Address Messages
@@ -1075,12 +1077,14 @@ authorisedOfficialsDOB.checkYourAnswersLabel = Date of birth
 authorisedOfficialsPhoneNumber.title = Authorised official’s phone numbers
 authorisedOfficialsPhoneNumber.heading = {0}’s phone numbers
 authorisedOfficialsPhoneNumber.mainPhoneNumber.label = Main phone number
-authorisedOfficialsPhoneNumber.mainPhoneNumber.error.format = Enter their main phone number, like 01632 960 001
+authorisedOfficialsPhoneNumber.mainPhoneNumber.error.format = Enter the authorised official’s main phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 authorisedOfficialsPhoneNumber.mainPhoneNumber.error.required = Enter their main phone number
+authorisedOfficialsPhoneNumber.mainPhoneNumber.hint = For international numbers include the country code
 authorisedOfficialsPhoneNumber.alternativePhoneNumber.label = Alternative phone number (optional)
-authorisedOfficialsPhoneNumber.alternativePhoneNumber.error.format = Enter their alternative phone number, like 01632 960 001
+authorisedOfficialsPhoneNumber.alternativePhoneNumber.error.format = Enter the authorised official’s alternative phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 authorisedOfficialsPhoneNumber.mainPhoneNumber.checkYourAnswersLabel = Main phone number
 authorisedOfficialsPhoneNumber.alternativePhoneNumber.checkYourAnswersLabel = Alternative phone number
+authorisedOfficialsPhoneNumber.alternativePhoneNumber.hint = For international numbers include the country code
 
 authorisedOfficialsPhoneNumber.checkYourAnswersLabel = Phone Number
 
@@ -1291,13 +1295,14 @@ otherOfficialsDOB.checkYourAnswersLabel = Date of birth
 otherOfficialsPhoneNumber.title = Other official’s phone numbers
 otherOfficialsPhoneNumber.heading = {0}’s phone numbers
 otherOfficialsPhoneNumber.mainPhoneNumber.label = Main phone number
-otherOfficialsPhoneNumber.mainPhoneNumber.error.format = Enter their main phone number, like 01632 960 001
+otherOfficialsPhoneNumber.mainPhoneNumber.error.format = Enter the official’s main phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 otherOfficialsPhoneNumber.mainPhoneNumber.error.required = Enter their main phone number
+otherOfficialsPhoneNumber.mainPhoneNumber.hint = For international numbers include the country code
 otherOfficialsPhoneNumber.alternativePhoneNumber.label = Alternative phone number (optional)
-otherOfficialsPhoneNumber.alternativePhoneNumber.error.format = Enter their alternative phone number, like 01632 960 001
+otherOfficialsPhoneNumber.alternativePhoneNumber.error.format = Enter the official’s alternative phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 otherOfficialsPhoneNumber.mainPhoneNumber.checkYourAnswersLabel = Main phone number
 otherOfficialsPhoneNumber.alternativePhoneNumber.checkYourAnswersLabel = Alternative phone number
-
+otherOfficialsPhoneNumber.alternativePhoneNumber.hint = For international numbers include the country code
 otherOfficialsPhoneNumber.checkYourAnswersLabel = Phone Number
 
 # Other Official Position Messages
@@ -1519,12 +1524,13 @@ individualNomineeDOB.checkYourAnswersLabel = Date of birth
 individualNomineesPhoneNumber.title = Nominee’s phone numbers
 individualNomineesPhoneNumber.heading = {0}’s phone numbers
 individualNomineesPhoneNumber.mainPhoneNumber.label = Main phone number
-individualNomineesPhoneNumber.mainPhoneNumber.error.format = Enter their main phone number, like 01632 960 001
+individualNomineesPhoneNumber.mainPhoneNumber.error.format = Enter the nominee’s main phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 individualNomineesPhoneNumber.mainPhoneNumber.error.required = Enter their main phone number
+individualNomineesPhoneNumber.mainPhoneNumber.hint = For international numbers include the country code
 individualNomineesPhoneNumber.alternativePhoneNumber.label = Alternative phone number (optional)
-individualNomineesPhoneNumber.alternativePhoneNumber.error.format = Enter their alternative phone number, like 01632 960 001, 07700 900 982 or +44 0808 157 019
+individualNomineesPhoneNumber.alternativePhoneNumber.error.format = Enter the nominee’s alternative phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 individualNomineesPhoneNumber.alternativePhoneNumber.error.required = Enter their alternative phone number
-
+individualNomineesPhoneNumber.alternativePhoneNumber.hint = For international numbers include the country code
 individualNomineesPhoneNumber.mainPhoneNumber.checkYourAnswersLabel = Main phone number
 individualNomineesPhoneNumber.alternativePhoneNumber.checkYourAnswersLabel = Alternative phone number
 
@@ -1677,7 +1683,8 @@ nameOfOrganisation.checkYourAnswersLabel = Name
 organisationContactDetails.title = Nominee organisation’s contact details
 organisationContactDetails.heading = {0}’s contact details
 organisationContactDetails.phoneNumber.label = Phone number
-organisationContactDetails.phoneNumber.error.format = Enter the organisation’s main phone number, like 01632 960 001
+organisationContactDetails.phoneNumber.hint = For international numbers include the country code
+organisationContactDetails.phoneNumber.error.format = Enter the organisation’s phone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192
 organisationContactDetails.phoneNumber.error.required = Enter the organisation’s phone number
 organisationContactDetails.email.label = Email address
 organisationContactDetails.email.error.format = Enter the email address in the correct format, like name@example.com

--- a/test/forms/common/PhoneNumberFormProviderSpec.scala
+++ b/test/forms/common/PhoneNumberFormProviderSpec.scala
@@ -105,9 +105,29 @@ class PhoneNumberFormProviderSpec extends StringFieldBehaviours {
       "01632 960 001" must fullyMatch regex formProvider.validateTelephoneNumber
     }
 
-    "be valid for 01632 960" in {
+    "be invalid for short numbers like 01632 960" in {
 
       "01632 960" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be invalid for special chars like (0)1632 960 001" in {
+
+      "(0)1632 960 001" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be invalid for hyphens like 1-632-960-001" in {
+
+      "1-632-960-001" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be invalid for dots like 1.632.960.001" in {
+
+      "1.632.960.001" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be valid for international numbers like +44 777 777 7777" in {
+
+      "+44 777 777 7777" must fullyMatch regex formProvider.validateTelephoneNumber
     }
   }
 }

--- a/test/forms/contactDetails/CharityContactDetailsFormProviderSpec.scala
+++ b/test/forms/contactDetails/CharityContactDetailsFormProviderSpec.scala
@@ -144,9 +144,29 @@ class CharityContactDetailsFormProviderSpec extends StringFieldBehaviours {
       "01632 960 001" must fullyMatch regex formProvider.validateTelephoneNumber
     }
 
-    "valid for 01632 960" in {
+    "be invalid for short numbers like 01632 960" in {
 
       "01632 960" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be invalid for special chars like (0)1632 960 001" in {
+
+      "(0)1632 960 001" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be invalid for hyphens like 1-632-960-001" in {
+
+      "1-632-960-001" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be invalid for dots like 1.632.960.001" in {
+
+      "1.632.960.001" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be valid for international numbers like +44 777 777 7777" in {
+
+      "+44 777 777 7777" must fullyMatch regex formProvider.validateTelephoneNumber
     }
   }
 

--- a/test/forms/nominees/OrganisationNomineeContactDetailsFormProviderSpec.scala
+++ b/test/forms/nominees/OrganisationNomineeContactDetailsFormProviderSpec.scala
@@ -115,9 +115,29 @@ class OrganisationNomineeContactDetailsFormProviderSpec extends StringFieldBehav
       "01632 960 001" must fullyMatch regex formProvider.validateTelephoneNumber
     }
 
-    "be valid for 01632 960" in {
+    "be invalid for short numbers like 01632 960" in {
 
       "01632 960" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be invalid for special chars like (0)1632 960 001" in {
+
+      "(0)1632 960 001" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be invalid for hyphens like 1-632-960-001" in {
+
+      "1-632-960-001" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be invalid for dots like 1.632.960.001" in {
+
+      "1.632.960.001" mustNot fullyMatch regex formProvider.validateTelephoneNumber
+    }
+
+    "be valid for international numbers like +44 777 777 7777" in {
+
+      "+44 777 777 7777" must fullyMatch regex formProvider.validateTelephoneNumber
     }
   }
 


### PR DESCRIPTION
# DDCE-3836

- Regex changed for validate phone number is changed to accommodate international phone numbers ^\ +?(?:\s*\d){10,20}$
- The hint text added to all telephone pages
- Welsh hint text implemented
- All automated tests are passing locally
- unit tests are updated to validate the main and alternative telephone numbers that could potentially take international phone numbers going forward

## Checklist PR Raiser
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date

## Checklist PR Reviewer
 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions (Performance tests where relevant)
 - [ ]  I've squashed my commits - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
