### PR TITLE
DDCE-4480: Amend eligibility page for charities outside UK

### DIFF
--- a/app/controllers/RegistrationSentController.scala
+++ b/app/controllers/RegistrationSentController.scala
@@ -61,7 +61,8 @@ class RegistrationSentController @Inject() (
           case _ if appConfig.noEmailPost                 => Future.successful(Ok(renderView(false, true)))
           case _                                          => Future.successful(Redirect(controllers.routes.EmailOrPostController.onPageLoad))
         }
-      case _                                                                 => Future.successful(Redirect(controllers.routes.PageNotFoundController.onPageLoad()))
+      case _                                                                 =>
+        Future.successful(Redirect(controllers.routes.PageNotFoundController.onPageLoad()))
     }
   }
 

--- a/app/views/checkEligibility/IsEligibleLocationOtherView.scala.html
+++ b/app/views/checkEligibility/IsEligibleLocationOtherView.scala.html
@@ -23,7 +23,11 @@
     govukLayout: templates.GovukLayoutWrapper,
     formHelper: FormWithCSRF,
     errorSummary: components.errorSummary,
-    yesNoRadio: components.yesNoRadio,
+    p: components.p,
+    h1: components.h1,
+    h2: components.h2,
+    bullets: components.bullets,
+    summaryYesNo: components.summaryYesNo,
     button: components.button
 )
 
@@ -35,55 +39,17 @@
 
         @errorSummary(form.errors)
 
-        @yesNoRadio(form, "isEligibleLocationOther.heading")
+        @h1("isEligibleLocationOther.heading")
 
-        <details class="govuk-details" data-module="govuk-details">
-            <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                  @messages("isEligibleLocationOther.details")
-                </span>
-            </summary>
-            <div class="govuk-details__text">
-                <ul class="govuk-list govuk-list--bullet">
-                    @countriesList.map { country => <li>@country</li>}
-                </ul>
-            </div>
-        </details>
+        @p(Html(messages("isEligibleLocationOther.p1")))
+
+        @p(Html(messages("isEligibleLocationOther.p2")))
+
+        @bullets("isEligibleLocationOther.b1", "isEligibleLocationOther.b2", "isEligibleLocationOther.b3", "isEligibleLocationOther.b4")()
+
+        @summaryYesNo(form, Some("isEligibleLocationOther.h2"), inlineRadio = false)
 
         @button("site.continue")
 
     }
-}
-
-@countriesList() = @{
-    val countries = List(
-        messages("isEligibleLocationOther.austria"),
-        messages("isEligibleLocationOther.belgium"),
-        messages("isEligibleLocationOther.bulgaria"),
-        messages("isEligibleLocationOther.croatia"),
-        messages("isEligibleLocationOther.republicOfCyprus"),
-        messages("isEligibleLocationOther.czechRepublic"),
-        messages("isEligibleLocationOther.denmark"),
-        messages("isEligibleLocationOther.estonia"),
-        messages("isEligibleLocationOther.finland"),
-        messages("isEligibleLocationOther.france"),
-        messages("isEligibleLocationOther.germany"),
-        messages("isEligibleLocationOther.greece"),
-        messages("isEligibleLocationOther.hungary"),
-        messages("isEligibleLocationOther.ireland"),
-        messages("isEligibleLocationOther.italy"),
-        messages("isEligibleLocationOther.latvia"),
-        messages("isEligibleLocationOther.lithuania"),
-        messages("isEligibleLocationOther.luxembourg"),
-        messages("isEligibleLocationOther.malta"),
-        messages("isEligibleLocationOther.netherlands"),
-        messages("isEligibleLocationOther.poland"),
-        messages("isEligibleLocationOther.portugal"),
-        messages("isEligibleLocationOther.romania"),
-        messages("isEligibleLocationOther.slovakia"),
-        messages("isEligibleLocationOther.slovenia"),
-        messages("isEligibleLocationOther.spain"),
-        messages("isEligibleLocationOther.sweden")
-    )
-    if (messages.lang.code == "cy") countries.sorted else countries
 }

--- a/app/views/components/summaryYesNo.scala.html
+++ b/app/views/components/summaryYesNo.scala.html
@@ -19,10 +19,10 @@
         h2: components.h2
 )
 
-@(form: Form[_], h2Message: Option[String], hintMessage: Option[String], keyPrefix: String = "site", hintHtml: Option[Html] = None)(implicit messages: Messages)
+@(form: Form[_], h2Message: Option[String], hintMessage: Option[String] = None, keyPrefix: String = "site", hintHtml: Option[Html] = None, inlineRadio: Boolean = true)(implicit messages: Messages)
 
 @govukRadios(Radios(
-    classes = "govuk-radios--inline",
+    classes = if(inlineRadio)"govuk-radios--inline" else "govuk-radios",
     idPrefix = None,
     name = "value",
     fieldset = Some(Fieldset(

--- a/build.sbt
+++ b/build.sbt
@@ -1,25 +1,20 @@
 import play.sbt.routes.RoutesKeys
 import scoverage.ScoverageKeys
-import uk.gov.hmrc.DefaultBuildSettings
-import uk.gov.hmrc.DefaultBuildSettings.addTestReportOption
-import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
+import uk.gov.hmrc.DefaultBuildSettings.*
 
 lazy val appName: String = "charities-registration-frontend"
 
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin)
-  .settings(DefaultBuildSettings.scalaSettings)
-  .settings(DefaultBuildSettings.defaultSettings())
-  .settings(inConfig(IntegrationTest)(DefaultBuildSettings.integrationTestSettings()))
+  .settings(scalaSettings)
+  .settings(defaultSettings())
+  .settings(inConfig(IntegrationTest)(integrationTestSettings()))
   .configs(IntegrationTest)
   .settings(
     javaOptions += "-Dlogger.resource=logback-test.xml",
-    IntegrationTest / unmanagedSourceDirectories := (IntegrationTest / baseDirectory)(base => Seq(base / "it")).value,
     IntegrationTest / resourceDirectory := (IntegrationTest / baseDirectory)(base => base / "it" / "resources").value,
-    IntegrationTest / parallelExecution := false,
-    IntegrationTest / fork := true,
-    addTestReportOption(IntegrationTest, "int-test-reports")
+    IntegrationTest / fork := true
   )
   .settings(majorVersion := 0)
   // To resolve dependency clash between flexmark v0.64.4+ and play-language to run accessibility tests, remove when versions align

--- a/conf/checkEligibility.routes
+++ b/conf/checkEligibility.routes
@@ -10,8 +10,8 @@ POST       /bank-account                             controllers.checkEligibilit
 GET        /uk-based                                 controllers.checkEligibility.IsEligibleLocationController.onPageLoad(mode: Mode = NormalMode)
 POST       /uk-based                                 controllers.checkEligibility.IsEligibleLocationController.onSubmit(mode: Mode = NormalMode)
 
-GET        /eea-based                                controllers.checkEligibility.IsEligibleLocationOtherController.onPageLoad(mode: Mode = NormalMode)
-POST       /eea-based                                controllers.checkEligibility.IsEligibleLocationOtherController.onSubmit(mode: Mode = NormalMode)
+GET        /non-uk-based                             controllers.checkEligibility.IsEligibleLocationOtherController.onPageLoad(mode: Mode = NormalMode)
+POST       /non-uk-based                             controllers.checkEligibility.IsEligibleLocationOtherController.onSubmit(mode: Mode = NormalMode)
 
 GET        /incorrect-details                        controllers.checkEligibility.IncorrectDetailsController.onPageLoad
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -350,38 +350,16 @@ isEligibleLocation.error.required = Dewiswch ‘Iawn’ os yw’r elusen wedi’
 
 # IsEligibleLocationOtherPage Messages
 # ----------------------------------------------------------
-isEligibleLocationOther.title = A yw’r elusen wedi’i lleoli yn yr Undeb Ewropeaidd, Gwlad yr Iâ, Liechtenstein neu Norwy?
-isEligibleLocationOther.heading = A yw’r elusen wedi’i lleoli yn yr Undeb Ewropeaidd, Gwlad yr Iâ, Liechtenstein neu Norwy?
-isEligibleLocationOther.details = Gwledydd yn yr Undeb Ewropeaidd
-isEligibleLocationOther.austria = Awstria
-isEligibleLocationOther.belgium = Gwlad Belg
-isEligibleLocationOther.bulgaria = Bwlgaria
-isEligibleLocationOther.croatia = Croatia
-isEligibleLocationOther.republicOfCyprus = Gweriniaeth Cyprus
-isEligibleLocationOther.czechRepublic = Y Weriniaeth Tsiec
-isEligibleLocationOther.denmark = Denmarc
-isEligibleLocationOther.estonia = Estonia
-isEligibleLocationOther.finland = Y Ffindir
-isEligibleLocationOther.france = Ffrainc
-isEligibleLocationOther.germany = Yr Almaen
-isEligibleLocationOther.greece = Gwlad Groeg
-isEligibleLocationOther.hungary = Hwngari
-isEligibleLocationOther.ireland = Iwerddon
-isEligibleLocationOther.italy = Yr Eidal
-isEligibleLocationOther.latvia = Latvia
-isEligibleLocationOther.lithuania = Lithuania
-isEligibleLocationOther.luxembourg = Lwcsembwrg
-isEligibleLocationOther.malta = Malta
-isEligibleLocationOther.netherlands = Yr Iseldiroedd
-isEligibleLocationOther.poland = Gwlad Pwyl
-isEligibleLocationOther.portugal = Portiwgal
-isEligibleLocationOther.romania = România
-isEligibleLocationOther.slovakia = Slofakia
-isEligibleLocationOther.slovenia = Slofenia
-isEligibleLocationOther.spain = Sbaen
-isEligibleLocationOther.sweden = Sweden
-isEligibleLocationOther.checkYourAnswersLabel = A yw’ch elusen wedi’i lleoli yn yr Undeb Ewropeaidd, Gwlad yr Iâ, Liechtenstein neu Norwy?
-isEligibleLocationOther.error.required = Dewiswch ‘Iawn’ os yw’r elusen wedi’i lleoli yn yr Undeb Ewropeaidd, Gwlad yr Iâ, Liechtenstein neu Norwy
+isEligibleLocationOther.title = Elusennau nad ydynt wedi’u lleoli yn y DU
+isEligibleLocationOther.heading = Elusennau nad ydynt wedi’u lleoli yn y DU
+isEligibleLocationOther.h2 = A yw’r elusen yn cael ei llywodraethu gan gyfraith Cymru a Lloegr, Gogledd Iwerddon neu’r Alban?
+isEligibleLocationOther.p1 = Os nad yw’r elusen wedi’i lleoli yn y DU, mae’n bosibl y gallwch ei chofrestru o hyd os yw’n cael ei llywodraethu gan gyfraith Cymru a Lloegr, Gogledd Iwerddon neu’r Alban.
+isEligibleLocationOther.p2 = Mae’r elusen yn cael ei llywodraethu gan gyfraith Cymru a Lloegr, Gogledd Iwerddon neu’r Alban os (yw un neu fwy o’r canlynol yn berthnasol):
+isEligibleLocationOther.b1 = mae dogfen lywodraethu’r elusen yn mabwysiadu cyfraith Cymru a Lloegr, Gogledd Iwerddon neu’r Alban i’w llywodraethu
+isEligibleLocationOther.b2 = mae’r rhan fwyaf o ymddiriedolwyr yr elusen yn byw yn y DU
+isEligibleLocationOther.b3 = mae’r rhan fwyaf o eiddo’r elusen yn y DU
+isEligibleLocationOther.b4 = mae gweinyddiaeth gyffredinol yr elusen yn cael ei gwneud yn y DU
+isEligibleLocationOther.error.required = Dewiswch ‘Iawn’ os yw’r elusen yn cael ei llywodraethu gan gyfraith Cymru a Lloegr, Gogledd Iwerddon neu’r Alban.
 
 # InEligible Page Messages
 # ----------------------------------------------------------

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -350,38 +350,16 @@ isEligibleLocation.error.required = Select yes if the charity is based in the UK
 
 # IsEligibleLocationOtherPage Messages
 # ----------------------------------------------------------
-isEligibleLocationOther.title = Is the charity based in the European Union, Iceland, Liechtenstein or Norway?
-isEligibleLocationOther.heading = Is the charity based in the European Union, Iceland, Liechtenstein or Norway?
-isEligibleLocationOther.details = Countries in the European Union
-isEligibleLocationOther.austria = Austria
-isEligibleLocationOther.belgium = Belgium
-isEligibleLocationOther.bulgaria = Bulgaria
-isEligibleLocationOther.croatia = Croatia
-isEligibleLocationOther.republicOfCyprus = Republic of Cyprus
-isEligibleLocationOther.czechRepublic = Czech Republic
-isEligibleLocationOther.denmark = Denmark
-isEligibleLocationOther.estonia = Estonia
-isEligibleLocationOther.finland = Finland
-isEligibleLocationOther.france = France
-isEligibleLocationOther.germany = Germany
-isEligibleLocationOther.greece = Greece
-isEligibleLocationOther.hungary = Hungary
-isEligibleLocationOther.ireland = Ireland
-isEligibleLocationOther.italy = Italy
-isEligibleLocationOther.latvia = Latvia
-isEligibleLocationOther.lithuania = Lithuania
-isEligibleLocationOther.luxembourg = Luxembourg
-isEligibleLocationOther.malta = Malta
-isEligibleLocationOther.netherlands = Netherlands
-isEligibleLocationOther.poland = Poland
-isEligibleLocationOther.portugal = Portugal
-isEligibleLocationOther.romania = Romania
-isEligibleLocationOther.slovakia = Slovakia
-isEligibleLocationOther.slovenia = Slovenia
-isEligibleLocationOther.spain = Spain
-isEligibleLocationOther.sweden = Sweden
-isEligibleLocationOther.checkYourAnswersLabel = Is your charity based in the European Union, Iceland, Liechtenstein or Norway?
-isEligibleLocationOther.error.required = Select yes if the charity is based in the European Union, Iceland, Liechtenstein or Norway
+isEligibleLocationOther.title = Charities that are not based in the UK
+isEligibleLocationOther.heading = Charities that are not based in the UK
+isEligibleLocationOther.h2 = Is the charity governed by the law of England and Wales, Northern Ireland or Scotland?
+isEligibleLocationOther.p1 = If the charity is not based in the UK you may still be able to register if it is governed by the law of England and Wales, Northern Ireland or Scotland.
+isEligibleLocationOther.p2 = The charity is governed by the law of England and Wales, Northern Ireland or Scotland if (one or more of the following apply):
+isEligibleLocationOther.b1 = the charity’s governing document adopts the law of England and Wales, Northern Ireland or Scotland to govern it
+isEligibleLocationOther.b2 = most of the charity’s trustees live in the UK
+isEligibleLocationOther.b3 = most of the charity’s property is in the UK
+isEligibleLocationOther.b4 = the charity’s general administration is done in the UK
+isEligibleLocationOther.error.required = Select yes if the charity is governed by the law of England and Wales, Northern Ireland or Scotland.
 
 # InEligible Page Messages
 # ----------------------------------------------------------

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,14 +3,14 @@ import sbt.*
 object AppDependencies {
 
   private lazy val mongoHmrcVersion     = "1.3.0"
-  private lazy val bootstrapPlayVersion = "7.19.0"
+  private lazy val bootstrapPlayVersion = "7.20.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"            % mongoHmrcVersion,
     "uk.gov.hmrc"       %% "play-conditional-form-mapping" % "1.13.0-play-28",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"    % bootstrapPlayVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "7.14.0-play-28",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc"            % "7.16.0-play-28",
     "uk.gov.hmrc"       %% "http-caching-client"           % "10.0.0-play-28",
     "uk.gov.hmrc"       %% "play-allowlist-filter"         % "1.2.0",
     "com.typesafe.play" %% "play-json-joda"                % "2.9.4"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 
 addSbtPlugin("uk.gov.hmrc"         % "sbt-auto-build"           % "3.9.0")
 addSbtPlugin("uk.gov.hmrc"         % "sbt-distributables"       % "2.2.0")
-addSbtPlugin("com.typesafe.play"   % "sbt-plugin"               % "2.8.19")
+addSbtPlugin("com.typesafe.play"   % "sbt-plugin"               % "2.8.20")
 addSbtPlugin("com.beautiful-scala" % "sbt-scalastyle"           % "1.5.1")
 addSbtPlugin("org.scoverage"       % "sbt-scoverage"            % "2.0.8")
 addSbtPlugin("org.scalameta"       % "sbt-scalafmt"             % "2.5.0")

--- a/test/models/OptionBinderSpec.scala
+++ b/test/models/OptionBinderSpec.scala
@@ -28,8 +28,8 @@ class OptionBinderSpec extends SpecBase {
 
       val pathBindable = implicitly[PathBindable[Option[Int]]]
 
-      val bind: Either[String, Option[Int]] = pathBindable.bind("foo", "123")
-      bind.value mustBe Some(123)
+      val bind: Either[String, Option[Int]] = pathBindable.bind("foo", "3")
+      bind.value mustBe Some(3)
     }
 
     "must bind value to Left" in {
@@ -44,9 +44,9 @@ class OptionBinderSpec extends SpecBase {
     "must unbind path" in {
 
       val pathBindable = implicitly[PathBindable[Option[Int]]]
-      val bindValue    = pathBindable.unbind("foo", Some(123))
+      val bindValue    = pathBindable.unbind("foo", Some(3))
 
-      bindValue mustBe "123"
+      bindValue mustBe "3"
     }
   }
 

--- a/test/repositories/SessionRepositorySpec.scala
+++ b/test/repositories/SessionRepositorySpec.scala
@@ -19,7 +19,7 @@ package repositories
 import config.FrontendAppConfig
 import models.UserAnswers
 import org.mongodb.scala.MongoCollection
-import org.mongodb.scala.model.{Filters, FindOneAndReplaceOptions, IndexModel, IndexOptions, Indexes}
+import org.mongodb.scala.model._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually.eventually
 import pages.checkEligibility.IsEligiblePurposePage
@@ -32,15 +32,15 @@ import scala.concurrent.duration.DurationInt
 
 class SessionRepositorySpec extends BaseMongoIndexSpec with BeforeAndAfterEach with MongoSupport {
 
-  private val config          = inject[FrontendAppConfig]
-  private lazy val repository = new SessionRepository(mongoComponent, config)
+  private val config: FrontendAppConfig = inject[FrontendAppConfig]
 
+  private lazy val repository: SessionRepository            = new SessionRepository(mongoComponent, config)
   private lazy val collection: MongoCollection[UserAnswers] = repository.collection
 
   private def findById(id: String, defaultValue: UserAnswers): UserAnswers =
     await(collection.find(Filters.equal("_id", id)).headOption().map(_.getOrElse(defaultValue)))
 
-  private lazy val eligibilityUserAnswers = emptyUserAnswers
+  private lazy val eligibilityUserAnswers: UserAnswers = emptyUserAnswers
     .set(IsEligiblePurposePage, true)
     .success
     .value
@@ -86,7 +86,7 @@ class SessionRepositorySpec extends BaseMongoIndexSpec with BeforeAndAfterEach w
         IndexModel(Indexes.ascending("_id"), IndexOptions().name("_id_"))
       )
 
-      await(repository.ensureIndexes)
+      await(repository.ensureIndexes())
 
       eventually(timeout(5.seconds), interval(100.milliseconds)) {
         assertIndexes(expectedIndexes.sorted, getIndexes(repository.collection).sorted)

--- a/test/transformers/submission/CharityCommonTransformerSpec.scala
+++ b/test/transformers/submission/CharityCommonTransformerSpec.scala
@@ -25,7 +25,7 @@ import pages.addressLookup.{AuthorisedOfficialAddressLookupPage, CharityOfficial
 import pages.authorisedOfficials.{AuthorisedOfficialsNamePage, AuthorisedOfficialsPhoneNumberPage, AuthorisedOfficialsPositionPage}
 import pages.contactDetails.{CanWeSendToThisAddressPage, CharityContactDetailsPage, CharityNamePage}
 import pages.operationsAndFunds.{BankDetailsPage, CharityEstablishedInPage}
-import play.api.libs.json.{Json, __}
+import play.api.libs.json.Json
 
 class CharityCommonTransformerSpec extends SpecBase {
 
@@ -34,6 +34,8 @@ class CharityCommonTransformerSpec extends SpecBase {
   "CharityCommonTransformer" when {
 
     "userAnswersToAdmin" must {
+
+      val sessionIdLength: Int = 50
 
       "convert the correct Admin object" in {
 
@@ -61,7 +63,7 @@ class CharityCommonTransformerSpec extends SpecBase {
           emptyUserAnswers.data.transform(jsonTransformer.userAnswersToAdmin(fakeDataRequestNoSessionId)).asOpt.value
         val sessionId = (json \ "charityRegistration" \ "common" \ "admin" \ "sessionID").as[String]
 
-        sessionId must have length 50
+        sessionId must have length sessionIdLength
         sessionId must not be empty
       }
 
@@ -70,7 +72,7 @@ class CharityCommonTransformerSpec extends SpecBase {
           emptyUserAnswers.data.transform(jsonTransformer.userAnswersToAdmin(fakeDataRequestEmptySessionId)).asOpt.value
         val sessionId = (json \ "charityRegistration" \ "common" \ "admin" \ "sessionID").as[String]
 
-        sessionId must have length 50
+        sessionId must have length sessionIdLength
         sessionId must not be empty
       }
 
@@ -79,7 +81,7 @@ class CharityCommonTransformerSpec extends SpecBase {
           emptyUserAnswers.data.transform(jsonTransformer.userAnswersToAdmin(fakeDataRequestShortSessionId)).asOpt.value
         val sessionId = (json \ "charityRegistration" \ "common" \ "admin" \ "sessionID").as[String]
 
-        sessionId must have length 50
+        sessionId must have length sessionIdLength
         sessionId must not be empty
         sessionId must startWith("short id here not 50 chars")
       }
@@ -91,9 +93,9 @@ class CharityCommonTransformerSpec extends SpecBase {
           .value
         val sessionId = (json \ "charityRegistration" \ "common" \ "admin" \ "sessionID").as[String]
 
-        sessionId must have length 50
+        sessionId must have length sessionIdLength
         sessionId must not be empty
-        sessionId mustBe ("short id here not 50 chars" * 10).take(50)
+        sessionId mustBe ("short id here not 50 chars" * 10).take(sessionIdLength)
       }
 
     }

--- a/test/views/checkEligibility/IsEligibleLocationOtherViewSpec.scala
+++ b/test/views/checkEligibility/IsEligibleLocationOtherViewSpec.scala
@@ -39,45 +39,11 @@ class IsEligibleLocationOtherViewSpec extends YesNoViewBehaviours {
 
     behave like normalPage(applyView(form), messageKeyPrefix)
 
-    behave like pageWithAdditionalGuidance(applyView(form), messageKeyPrefix, "details")
-
     behave like pageWithBackLink(applyView(form))
 
-    behave like yesNoPage(form, applyView, messageKeyPrefix)
+    behave like yesNoPage(form, applyView, messageKeyPrefix, legendKey = Some("h2"))
 
     behave like pageWithSubmitButton(applyView(form), BaseMessages.continue)
 
-    "display EU countries list" in {
-      assertContainsMessages(
-        asDocument(applyView(form)),
-        s"$messageKeyPrefix.austria",
-        s"$messageKeyPrefix.belgium",
-        s"$messageKeyPrefix.bulgaria",
-        s"$messageKeyPrefix.croatia",
-        s"$messageKeyPrefix.republicOfCyprus",
-        s"$messageKeyPrefix.czechRepublic",
-        s"$messageKeyPrefix.denmark",
-        s"$messageKeyPrefix.estonia",
-        s"$messageKeyPrefix.finland",
-        s"$messageKeyPrefix.france",
-        s"$messageKeyPrefix.germany",
-        s"$messageKeyPrefix.greece",
-        s"$messageKeyPrefix.hungary",
-        s"$messageKeyPrefix.ireland",
-        s"$messageKeyPrefix.italy",
-        s"$messageKeyPrefix.latvia",
-        s"$messageKeyPrefix.lithuania",
-        s"$messageKeyPrefix.luxembourg",
-        s"$messageKeyPrefix.malta",
-        s"$messageKeyPrefix.netherlands",
-        s"$messageKeyPrefix.poland",
-        s"$messageKeyPrefix.portugal",
-        s"$messageKeyPrefix.romania",
-        s"$messageKeyPrefix.slovakia",
-        s"$messageKeyPrefix.slovenia",
-        s"$messageKeyPrefix.spain",
-        s"$messageKeyPrefix.sweden"
-      )
-    }
   }
 }


### PR DESCRIPTION
### DDCE-4480: Amend eligibility page for charities outside UK

- Changed the page at `/register-charity-hmrc/check-eligibility/eea-based` to `/register-charity-hmrc/check-eligibility/non-uk-based`. Journey now checks with user if the charity is governed by UK law rather than being an EU country.
- Update dependencies
- AT PR
