### PR TITLE
DDCE-4510: Amend declaration page with additional prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ precompiled
 /.project
 project/project
 project/target
+project/.bloop
 project/metals.sbt
 /RUNNING_PID
 server.pid

--- a/app/controllers/DeclarationController.scala
+++ b/app/controllers/DeclarationController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import config.FrontendAppConfig
+import connectors.httpParsers.UnexpectedFailureException
 import controllers.actions.{AuthIdentifierAction, DataRequiredAction, UserDataRetrievalAction}
 import pages.{AcknowledgementReferencePage, ApplicationSubmissionDatePage}
 import play.api.Logger
@@ -25,11 +26,9 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import service.{CharitiesRegistrationService, UserAnswerService}
 import transformers.submission.CharitySubmissionTransformer
 import views.html.DeclarationView
+
 import java.time.LocalDate
-
-import connectors.httpParsers.UnexpectedFailureException
 import javax.inject.Inject
-
 import scala.concurrent.Future
 
 class DeclarationController @Inject() (

--- a/app/views/DeclarationView.scala.html
+++ b/app/views/DeclarationView.scala.html
@@ -23,6 +23,7 @@
     govukSummaryList: GovukSummaryList,
     h1: components.h1,
     p: components.p,
+    bullets: components.bullets,
     warning: components.warning,
     button: components.button,
     formHelper: FormWithCSRF
@@ -34,9 +35,13 @@
 
     @h1(messages("declaration.heading"))
 
-    @warning{@messages("declaration.warning")}
+    @p(Html(messages("declaration.p1")))
 
-    @p{@messages("declaration.p1")}
+    @bullets("declaration.b1", "declaration.b2", "declaration.b3", "declaration.b4", "declaration.b5", "declaration.b6")()
+
+    @p(Html(messages("declaration.p2")))
+
+    @warning(Html(messages("declaration.warning")))
 
     @formHelper(action = controllers.routes.DeclarationController.onSubmit, 'autoComplete -> "off") {
 

--- a/app/views/components/warning.scala.html
+++ b/app/views/components/warning.scala.html
@@ -21,7 +21,7 @@
 <div class="govuk-warning-text">
  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
  <strong class="govuk-warning-text__text">
-  <span class="govuk-warning-text__assistive">@content</span>
+  <span class="govuk-warning-text__assistive">Warning</span>
   @content
  </strong>
 </div>

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -216,8 +216,15 @@ startDeclaration.p = Bydd y tudalennau nesaf yn gofyn i chi gadarnhau datganiad 
 # ----------------------------------------------------------
 declaration.title = Datganiad
 declaration.heading = Datganiad
+declaration.p1 = Drwy anfon y cais hwn, rydych yn cadarnhau bod o leiaf un o’r canlynol yn wir:
+declaration.p2 = Rydych eisoes yn cadarnhau bod y wybodaeth rydych wedi’i rhoi yn y cais yn wir hyd eithaf eich gwybodaeth.
+declaration.b1 = mae’r elusen wedi’i lleoli yn y DU
+declaration.b2 = mae’r elusen wedi’i chofrestru gyda Chomisiwn Elusennau Cymru a Lloegr, Comisiwn Elusennau ar gyfer Gogledd Iwerddon neu Reoleiddiwr Elusennau’r Alban
+declaration.b3 = mae dogfen lywodraethu’r elusen yn mabwysiadu cyfraith Cymru a Lloegr, Gogledd Iwerddon neu’r Alban i’w llywodraethu
+declaration.b4 = mae’r rhan fwyaf o ymddiriedolwyr yr elusen yn byw yn y DU
+declaration.b5 = mae’r rhan fwyaf o eiddo’r elusen yn y DU
+declaration.b6 = mae gweinyddiaeth gyffredinol yr elusen yn cael ei gwneud yn y DU
 declaration.warning = Gellir eich erlid am roi gwybodaeth anwir neu gamarweiniol yn fwriadol ar eich cais.
-declaration.p1 = Drwy anfon y cais hwn, rwy’n cadarnhau bod yr wybodaeth a roddwyd gennyf yn wir hyd eithaf fy ngwybodaeth.
 
 # Required documents bullets Messages
 # ----------------------------------------------------------

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -216,8 +216,15 @@ startDeclaration.p = The next pages will ask you to confirm a declaration and se
 # ----------------------------------------------------------
 declaration.title = Declaration
 declaration.heading = Declaration
+declaration.p1 = By sending this application, you confirm that at least one of the following is true:
+declaration.p2 = You also confirm that the information you have provided in the application is true to the best of your knowledge.
+declaration.b1 = the charity is based in the UK
+declaration.b2 = the charity is registered with either the Charity Commission of England and Wales, the Charity Commission for Northern Ireland or the Scottish Charity Regulator
+declaration.b3 = the charity’s governing document adopts the law of England and Wales, Northern Ireland or Scotland to govern it
+declaration.b4 = most of the charity’s trustees live in the UK
+declaration.b5 = most of the charity’s property is in UK
+declaration.b6 = the charity’s general administration is done in the UK
 declaration.warning = You can be prosecuted for knowingly providing false or misleading information on your application.
-declaration.p1 = By sending this application, I confirm that the information I have provided is true to the best of my knowledge.
 
 # Required documents bullets Messages
 # ----------------------------------------------------------

--- a/test/views/DeclarationViewSpec.scala
+++ b/test/views/DeclarationViewSpec.scala
@@ -35,22 +35,23 @@ class DeclarationViewSpec extends ViewBehaviours {
   "DeclarationView" when {
     def test(method: String, view: HtmlFormat.Appendable): Unit =
       s"$method" must {
-        behave like normalPage(view, messageKeyPrefix, section = Some(messages("declaration.section")))
 
-        behave like pageWithAdditionalGuidance(view, messageKeyPrefix, "p1")
+        behave like normalPage(view, messageKeyPrefix, section = Some(messages("declaration.section")))
+        behave like pageWithAdditionalGuidance(view, messageKeyPrefix, "p1", "p2")
+
+        Seq(1, 2, 3, 4, 5, 6).foreach(i => behave like pageWithBulletedPoint(view, messages(s"declaration.b$i"), i))
 
         behave like pageWithBackLink(view)
-
         behave like pageWithWarningText(view, messages("declaration.warning"))
-
         behave like pageWithSubmitButton(view, messages("site.confirmAndSend"))
       }
 
-    val input: Seq[(String, HtmlFormat.Appendable)] = Seq(
-      (".apply", viewViaApply),
-      (".render", viewViaRender),
-      (".f", viewViaF)
-    )
+    val input: Seq[(String, HtmlFormat.Appendable)] =
+      Seq(
+        (".apply", viewViaApply),
+        (".render", viewViaRender),
+        (".f", viewViaF)
+      )
 
     input.foreach(args => (test _).tupled(args))
   }

--- a/test/views/behaviours/ViewBehaviours.scala
+++ b/test/views/behaviours/ViewBehaviours.scala
@@ -16,6 +16,8 @@
 
 package views.behaviours
 
+import org.jsoup.nodes.Document
+import org.jsoup.select.Elements
 import play.twirl.api.HtmlFormat
 import views.ViewSpecBase
 
@@ -34,7 +36,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
         "have the service name" in {
 
-          val doc = asDocument(view)
+          val doc: Document = asDocument(view)
 
           assert(
             doc.getElementsByClass("hmrc-header__service-name--linked").first.text == messages("service.name"),
@@ -44,7 +46,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
         "display the correct browser title" in {
 
-          val doc = asDocument(view)
+          val doc: Document = asDocument(view)
           assertEqualsMessage(
             doc,
             "title",
@@ -54,7 +56,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
         "display the correct page heading" in {
 
-          val doc = asDocument(view)
+          val doc: Document = asDocument(view)
           assertPageTitleEqualsMessage(doc, s"$messageKeyPrefix.heading$postHeadingString", headingArgs: _*)
         }
 
@@ -72,7 +74,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
       "have a back link" in {
 
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         assertRenderedById(doc, "back-link")
       }
     }
@@ -102,7 +104,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
       "have a Sign Out link" in {
 
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         assertRenderedByCssSelector(doc, "ul.govuk-header__navigation li:nth-of-type(1) a")
       }
     }
@@ -112,7 +114,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
       s"have a button with message '$msg'" in {
 
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         assertEqualsMessage(doc, "#main-content > div > div > div > form > button", msg)
       }
     }
@@ -122,7 +124,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
       s"have a button with message '$msg'" in {
 
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         assertEqualsMessage(doc, selector, msg)
       }
     }
@@ -132,7 +134,7 @@ trait ViewBehaviours extends ViewSpecBase {
       s"element with cssSelector '$cssSelector'" must {
 
         s"have message '$message'" in {
-          val doc = asDocument(view)
+          val doc: Document = asDocument(view)
           doc.select(cssSelector).first.text() mustBe message
         }
       }
@@ -142,7 +144,7 @@ trait ViewBehaviours extends ViewSpecBase {
     s"behave like a page with bullet point$bullet" must {
 
       s"have a button with message '$msg'" in {
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         assertEqualsMessage(
           doc,
           cssSelector = s"#main-content > div > div > div > ul > li:nth-child($bullet)",
@@ -164,10 +166,15 @@ trait ViewBehaviours extends ViewSpecBase {
 
       s"have a warning message '$msg'" in {
 
-        val doc = asDocument(view)
+        val doc: Document            = asDocument(view)
+        val warningElement: Elements = doc.getElementsByClass("govuk-warning-text__text")
 
         assert(
-          doc.getElementsByClass("govuk-warning-text__assistive").first.text == msg,
+          warningElement.select("span").text == "Warning",
+          s"\n Warning assistance text missing"
+        )
+        assert(
+          warningElement.first().ownText() == msg,
           s"\n Warning message did not contain text $msg"
         )
       }
@@ -178,7 +185,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
       s"have a button with message '$msg'" in {
 
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         assertEqualsMessage(doc, s"#main-content > div > div > div > form > p:nth-child($child)", msg)
       }
     }
@@ -192,7 +199,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
       "display the correct guidance" in {
 
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         for (key <- expectedGuidanceKeys) assertContainsText(doc, messages(s"$messageKeyPrefix.$key"))
       }
     }
@@ -202,7 +209,7 @@ trait ViewBehaviours extends ViewSpecBase {
 
       s"have a guidance message '$msg'" in {
 
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         assertEqualsMessage(doc, "#main-content > div > div > div > form > h1", msg)
       }
     }
@@ -210,14 +217,14 @@ trait ViewBehaviours extends ViewSpecBase {
   def pageWithMultiFieldError(view: HtmlFormat.Appendable, key: String): Unit =
     "behave like a page with a multiField error" in {
 
-      val doc = asDocument(view)
+      val doc: Document = asDocument(view)
       assertRenderedById(doc, s"$key-multiField-error-message")
     }
 
   def pageWithHyperLink(view: => HtmlFormat.Appendable, linkId: String, url: String = "#", linkText: String): Unit =
     "behave like a page with a hyperlink" must {
       "have a hyperlink" in {
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         assertRenderedById(doc, linkId)
         doc.select(s"#$linkId").attr("href") mustBe url
         doc.select(s"#$linkId").text() mustBe linkText
@@ -227,7 +234,7 @@ trait ViewBehaviours extends ViewSpecBase {
   def pageWithPrintOrDownloadLink(view: HtmlFormat.Appendable, linkId: String, url: String, linkText: String): Unit =
     "behave like a page with a Print or download link" must {
       "have a hyperlink" in {
-        val doc = asDocument(view)
+        val doc: Document = asDocument(view)
         doc.select(s"#$linkId").attr("href") mustBe url
         doc.select(s"#$linkId").text() mustBe linkText
       }


### PR DESCRIPTION
### DDCE-4510: Amend declaration page with additional prompts

- Updated page at `register-charity-hmrc/declare-and-send/declaration` to include prompts for checking the charities relation to the UK.