### PR TITLE
 Charities - make charity’s operating country number into words

### DIFF
--- a/app/viewmodels/operationsAndFunds/OverseasOperatingLocationSummaryHelper.scala
+++ b/app/viewmodels/operationsAndFunds/OverseasOperatingLocationSummaryHelper.scala
@@ -40,10 +40,10 @@ class OverseasOperatingLocationSummaryHelper(
   def overseasOperatingLocationSummaryRow(index: Int, changeLinkCall: Call): Option[SummaryListRow] =
     userAnswers.get(WhatCountryDoesTheCharityOperateInPage(index)).map { code =>
       summaryListRow(
-        label = messages("overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", index + 1),
+        label = messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.${index + 1}"),
         value = HtmlContent(countryService.find(code).fold(code)(_.name)),
         visuallyHiddenText =
-          Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", index + 1)),
+          Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.${index + 1}")),
         changeLinkCall -> messages("site.delete")
       )
     }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -886,7 +886,11 @@ overseasOperatingLocationSummary.addAnotherCountry.h2 = A ydych eisiau ychwanegu
 overseasOperatingLocationSummary.addAnotherCountry.hint = Gallwch ychwanegu hyd at 5 gwlad
 overseasOperatingLocationSummary.addAnotherCountry.warn = Ni allwch ychwanegu gwlad gweithredu arall
 overseasOperatingLocationSummary.addAnotherCountry.error.required = Dewiswch ‘Iawn’ os ydych am ychwanegu gwlad gweithredu arall
-overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel = Gwlad gweithredu {0}
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.1 = Gwlad weithredu gyntaf
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.2 = Ail wlad weithredu
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.3 = Trydedd wlad weithredu
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.4 = Pedwaredd wlad weithredu
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.5 = Pumed wlad weithredu
 overseasOperatingLocationSummary.checkYourAnswersLabel = Lleoliadau gweithredu dramor
 
 # Other FundRaising Messages

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -883,7 +883,11 @@ overseasOperatingLocationSummary.addAnotherCountry.h2 = Do you want to add anoth
 overseasOperatingLocationSummary.addAnotherCountry.hint = You can add up to 5 countries
 overseasOperatingLocationSummary.addAnotherCountry.warn = You cannot add another operating country.
 overseasOperatingLocationSummary.addAnotherCountry.error.required = Select yes if you want to add another operating country
-overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel = Operating country {0}
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.1 = First operating country
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.2 = Second operating country
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.3 = Third operating country
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.4 = Fourth operating country
+overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.5 = Fifth operating country
 overseasOperatingLocationSummary.checkYourAnswersLabel = Overseas operating locations
 
 # Other FundRaising Messages

--- a/test/viewModels/operationsAndFunds/OverseasOperatingLocationSummaryHelperSpec.scala
+++ b/test/viewModels/operationsAndFunds/OverseasOperatingLocationSummaryHelperSpec.scala
@@ -80,10 +80,10 @@ class OverseasOperatingLocationSummaryHelperSpec extends SpecBase with SummaryLi
 
         helper.overseasOperatingLocationSummaryRow(0, onwardRoute) mustBe Some(
           summaryListRow(
-            label = messages("overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 1),
+            label = messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.1"),
             value = HtmlContent("Thai"),
             visuallyHiddenText =
-              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 1)),
+              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.1")),
             onwardRoute -> BaseMessages.delete
           )
         )
@@ -96,42 +96,42 @@ class OverseasOperatingLocationSummaryHelperSpec extends SpecBase with SummaryLi
 
         helper.rows mustBe List(
           summaryListRow(
-            label = messages("overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 1),
+            label = messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.1"),
             value = HtmlContent("Thai"),
             visuallyHiddenText =
-              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 1)),
+              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.1")),
             operationFundsRoutes.IsRemoveOperatingCountryController
               .onPageLoad(NormalMode, Index(0)) -> BaseMessages.delete
           ),
           summaryListRow(
-            label = messages("overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 2),
+            label = messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.2"),
             value = HtmlContent("India"),
             visuallyHiddenText =
-              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 2)),
+              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.2")),
             operationFundsRoutes.IsRemoveOperatingCountryController
               .onPageLoad(NormalMode, Index(1)) -> BaseMessages.delete
           ),
           summaryListRow(
-            label = messages("overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 3),
+            label = messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.3"),
             value = HtmlContent("Portugal"),
             visuallyHiddenText =
-              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 3)),
+              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.3")),
             operationFundsRoutes.IsRemoveOperatingCountryController
               .onPageLoad(NormalMode, Index(2)) -> BaseMessages.delete
           ),
           summaryListRow(
-            label = messages("overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 4),
+            label = messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.4"),
             value = HtmlContent("Paraguay"),
             visuallyHiddenText =
-              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 4)),
+              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.4")),
             operationFundsRoutes.IsRemoveOperatingCountryController
               .onPageLoad(NormalMode, Index(3)) -> BaseMessages.delete
           ),
           summaryListRow(
-            label = messages("overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 5),
+            label = messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.5"),
             value = HtmlContent("Afghanistan"),
             visuallyHiddenText =
-              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel", 5)),
+              Some(messages(s"overseasOperatingLocationSummary.addAnotherCountry.checkYourAnswersLabel.5")),
             operationFundsRoutes.IsRemoveOperatingCountryController
               .onPageLoad(NormalMode, Index(4)) -> BaseMessages.delete
           )


### PR DESCRIPTION
Changed keys in messages.en and messages.cy so represented by ordinal numbers rather than index and edited tests to reflect this