### PR TITLE
charities-registration-frontend: Update Sign-Out Method to Use bas-gateway Endpoint

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -30,8 +30,8 @@ class FrontendAppConfig @Inject() (val servicesConfig: ServicesConfig) {
   lazy val host: String              = servicesConfig.getString("host")
   lazy val appName: String           = servicesConfig.getString("appName")
   lazy val govUK: String             = servicesConfig.getString("urls.govUK")
-  lazy val basGatewayBaseUrl: String = servicesConfig.getString("bas-gateway.host")
-  lazy val feedbackFrontend: String  = servicesConfig.getString("feedback-frontend.host")
+  lazy val basGatewayBaseUrl: String = servicesConfig.baseUrl("bas-gateway")
+  lazy val feedbackFrontend: String  = servicesConfig.baseUrl("feedback-frontend")
 
   private val contactHost: String = servicesConfig.getString("contact-frontend.host")
 

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -30,8 +30,8 @@ class FrontendAppConfig @Inject() (val servicesConfig: ServicesConfig) {
   lazy val host: String              = servicesConfig.getString("host")
   lazy val appName: String           = servicesConfig.getString("appName")
   lazy val govUK: String             = servicesConfig.getString("urls.govUK")
-  lazy val basGatewayBaseUrl: String = servicesConfig.baseUrl("bas-gateway")
-  lazy val feedbackFrontend: String  = servicesConfig.baseUrl("feedback-frontend")
+  lazy val basGatewayBaseUrl: String = servicesConfig.getString("bas-gateway.host")
+  lazy val feedbackFrontend: String  = servicesConfig.getString("feedback-frontend.host")
 
   private val contactHost: String = servicesConfig.getString("contact-frontend.host")
 

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -27,9 +27,11 @@ import scala.util.Try
 @Singleton
 class FrontendAppConfig @Inject() (val servicesConfig: ServicesConfig) {
 
-  lazy val host: String    = servicesConfig.getString("host")
-  lazy val appName: String = servicesConfig.getString("appName")
-  lazy val govUK: String   = servicesConfig.getString("urls.govUK")
+  lazy val host: String              = servicesConfig.getString("host")
+  lazy val appName: String           = servicesConfig.getString("appName")
+  lazy val govUK: String             = servicesConfig.getString("urls.govUK")
+  lazy val basGatewayBaseUrl: String = servicesConfig.baseUrl("bas-gateway")
+  lazy val feedbackFrontend: String  = servicesConfig.baseUrl("feedback-frontend")
 
   private val contactHost: String = servicesConfig.getString("contact-frontend.host")
 
@@ -37,16 +39,14 @@ class FrontendAppConfig @Inject() (val servicesConfig: ServicesConfig) {
 
   lazy val contactUrl: String = s"$contactHost/contact/contact-hmrc?service=$contactFormServiceIdentifier"
 
-  private val exitSurveyHost: String = servicesConfig.getString("feedback-frontend.host")
-
   lazy val userAnswersTimeToLive: Long =
     servicesConfig.getInt("mongodb.user-eligibility-answers.timeToLiveInSeconds").toLong
 
-  def exitSurveyUrl: String = s"$exitSurveyHost/feedback/CHARITIES"
+  def exitSurveyUrl: String = s"$feedbackFrontend/feedback/CHARITIES"
 
   lazy val loginUrl: String                         = servicesConfig.getString("urls.login")
   lazy val registerUrl: String                      = servicesConfig.getString("urls.register")
-  lazy val signOutUrl: String                       = servicesConfig.getString("urls.signOut")
+  lazy val signOutUrl: String                       = s"$basGatewayBaseUrl/bas-gateway/sign-out-without-state"
   lazy val loginContinueUrl: String                 = servicesConfig.getString("urls.loginContinue")
   lazy val incorrectDetailsLoginContinueUrl: String = servicesConfig.getString("urls.incorrectDetailsLoginContinue")
   lazy val loginContinueKey: String                 = servicesConfig.getString("urls.continue")

--- a/app/connectors/addressLookup/AddressLookupConfiguration.scala
+++ b/app/connectors/addressLookup/AddressLookupConfiguration.scala
@@ -34,7 +34,7 @@ class AddressLookupConfiguration @Inject() (
     val welsh   = Lang("cy")
 
     val fullCallbackURL = appConfig.host + callbackUrl
-    val fullSignOutURL  = controllers.routes.SignOutController.signOut.url
+    val fullSignOutURL  = controllers.routes.SignOutController.signOut().url
 
     AddressLookupConfigurationModel(
       version = 2,

--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -31,6 +31,15 @@ class SignOutController @Inject() (val controllerComponents: MessagesControllerC
   }
 
   def signedYouOut: Action[AnyContent] = Action { implicit request =>
-    Ok(view()).withNewSession
+    Ok(view())
   }
+
+  def signOutNoSurvey(): Action[AnyContent] = Action { implicit request =>
+    val signOutServiceUrl = appConfig.host + routes.SignOutController.signedYouOut.url
+    Redirect(
+      appConfig.signOutUrl,
+      Map("continue" -> Seq(signOutServiceUrl))
+    )
+  }
+
 }

--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -26,8 +26,8 @@ class SignOutController @Inject() (val controllerComponents: MessagesControllerC
   implicit appConfig: FrontendAppConfig
 ) extends LocalBaseController {
 
-  def signOut: Action[AnyContent] = Action { _ =>
-    Redirect(appConfig.signOutUrl).withNewSession
+  def signOut(): Action[AnyContent] = Action { implicit request =>
+    Redirect(appConfig.signOutUrl, Map("continue" -> Seq(appConfig.exitSurveyUrl)))
   }
 
   def signedYouOut: Action[AnyContent] = Action { implicit request =>

--- a/app/views/templates/GovukLayoutWrapper.scala.html
+++ b/app/views/templates/GovukLayoutWrapper.scala.html
@@ -57,7 +57,7 @@
             countdown = Some(appConfig.countdown),
             keepAliveUrl = Some(controllers.routes.IndexController.keepalive.url),
             signOutUrl = Some(controllers.routes.SignOutController.signOut().url),
-            timeoutUrl = Some(controllers.routes.SignOutController.signOutNoSurvey().url),
+            timeoutUrl = Some(controllers.routes.SignOutController.signedYouOut.url),
             language = if (messages.lang.code == "cy") Some("cy") else Some("en")
         ))
     } else if(timeout) {

--- a/app/views/templates/GovukLayoutWrapper.scala.html
+++ b/app/views/templates/GovukLayoutWrapper.scala.html
@@ -57,7 +57,7 @@
             countdown = Some(appConfig.countdown),
             keepAliveUrl = Some(controllers.routes.IndexController.keepalive.url),
             signOutUrl = Some(controllers.routes.SignOutController.signOut().url),
-            timeoutUrl = Some(controllers.routes.SignOutController.signedYouOut.url),
+            timeoutUrl = Some(controllers.routes.SignOutController.signOutNoSurvey().url),
             language = if (messages.lang.code == "cy") Some("cy") else Some("en")
         ))
     } else if(timeout) {

--- a/app/views/templates/GovukLayoutWrapper.scala.html
+++ b/app/views/templates/GovukLayoutWrapper.scala.html
@@ -56,7 +56,7 @@
             timeout = Some(appConfig.timeout),
             countdown = Some(appConfig.countdown),
             keepAliveUrl = Some(controllers.routes.IndexController.keepalive.url),
-            signOutUrl = Some(controllers.routes.SignOutController.signOut.url),
+            signOutUrl = Some(controllers.routes.SignOutController.signOut().url),
             timeoutUrl = Some(controllers.routes.SignOutController.signedYouOut.url),
             language = if (messages.lang.code == "cy") Some("cy") else Some("en")
         ))
@@ -107,7 +107,7 @@
   pageTitle = pageTitle,
   headBlock = Some(hmrcHead(headBlock = Some(head))),
   headerBlock = Some(header(Header(
-    signOutHref = if(signOut) Some(controllers.routes.SignOutController.signOut.url) else None,
+    signOutHref = if(signOut) Some(controllers.routes.SignOutController.signOut().url) else None,
     homepageUrl = appConfig.govUK,
     serviceName = Some(messages("service.name")),
     serviceUrl = if(signOut) controllers.routes.IndexController.onPageLoad(None).url else appConfig.signOutUrl,

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -21,7 +21,7 @@ GET        /register-new-account                        controllers.IndexControl
 ### SignOut/Session Expired
 GET        /page-not-found                              controllers.PageNotFoundController.onPageLoad()
 GET        /redirect-to-start-of-journey                controllers.PageNotFoundController.redirectToStartOfJourney()
-GET        /sign-out                                    controllers.SignOutController.signOut
+GET        /sign-out                                    controllers.SignOutController.signOut()
 GET        /error/signed-you-out                        controllers.SignOutController.signedYouOut
 GET        /you-deleted-your-answers                    controllers.DeleteAnswersController.youDeletedAnswers
 GET        /we-deleted-your-answers                     controllers.DeleteAnswersController.weDeletedYourAnswers

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -22,7 +22,8 @@ GET        /register-new-account                        controllers.IndexControl
 GET        /page-not-found                              controllers.PageNotFoundController.onPageLoad()
 GET        /redirect-to-start-of-journey                controllers.PageNotFoundController.redirectToStartOfJourney()
 GET        /sign-out                                    controllers.SignOutController.signOut()
-GET        /error/signed-you-out                        controllers.SignOutController.signedYouOut
+GET        /sign-you-out                                controllers.SignOutController.signedYouOut
+GET        /error/signed-you-out                        controllers.SignOutController.signOutNoSurvey()
 GET        /you-deleted-your-answers                    controllers.DeleteAnswersController.youDeletedAnswers
 GET        /we-deleted-your-answers                     controllers.DeleteAnswersController.weDeletedYourAnswers
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -22,8 +22,7 @@ GET        /register-new-account                        controllers.IndexControl
 GET        /page-not-found                              controllers.PageNotFoundController.onPageLoad()
 GET        /redirect-to-start-of-journey                controllers.PageNotFoundController.redirectToStartOfJourney()
 GET        /sign-out                                    controllers.SignOutController.signOut()
-GET        /sign-you-out                                controllers.SignOutController.signedYouOut
-GET        /error/signed-you-out                        controllers.SignOutController.signOutNoSurvey()
+GET        /error/signed-you-out                        controllers.SignOutController.signedYouOut
 GET        /you-deleted-your-answers                    controllers.DeleteAnswersController.youDeletedAnswers
 GET        /we-deleted-your-answers                     controllers.DeleteAnswersController.weDeletedYourAnswers
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -50,6 +50,23 @@ microservice {
       host = localhost
       port = 9329
     }
+
+    bas-gateway {
+       host     = localhost
+       port     = 9553
+    }
+
+    feedback-frontend {
+        protocol = http
+        host     = localhost
+        port     = 9514
+    }
+
+    bank-account-reputation {
+      protocol = http
+      host = localhost
+      port = 9871
+    }
   }
 }
 
@@ -61,10 +78,6 @@ tracking-consent-frontend {
 
 contact-frontend {
   host = "http://localhost:9250"
-}
-
-feedback-frontend {
-  host = "http://localhost:9514"
 }
 
 mongodb {
@@ -84,7 +97,6 @@ urls {
   register = "http://localhost:9949/auth-login-stub/gg-sign-in"
   continue = "continue"
   registration = "continue"
-  signOut = "https://www.gov.uk/charity-recognition-hmrc"
   loginContinue = "http://localhost:9457/register-charity-hmrc/task-list"
   incorrectDetailsLoginContinue = "http://localhost:9457/register-charity-hmrc/check-eligibility/charitable-purposes"
   getRecognition = "https://www.gov.uk/charities-and-tax/get-recognition"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -61,12 +61,6 @@ microservice {
         host     = localhost
         port     = 9514
     }
-
-    bank-account-reputation {
-      protocol = http
-      host = localhost
-      port = 9871
-    }
   }
 }
 
@@ -79,15 +73,6 @@ tracking-consent-frontend {
 contact-frontend {
   host = "http://localhost:9250"
 }
-
-feedback-frontend {
-  host = "http://localhost:9514"
-}
-
-bas-gateway {
-  host = "http://localhost:9553"
-}
-
 
 mongodb {
   uri = "mongodb://localhost:27017/"${appName}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,17 @@ microservice {
       port = 9329
     }
 
+    bas-gateway {
+       host     = localhost
+       port     = 9553
+    }
+
+    feedback-frontend {
+        protocol = http
+        host     = localhost
+        port     = 9514
+    }
+
     bank-account-reputation {
       protocol = http
       host = localhost
@@ -68,15 +79,6 @@ tracking-consent-frontend {
 contact-frontend {
   host = "http://localhost:9250"
 }
-
-feedback-frontend {
-  host = "http://localhost:9514"
-}
-
-bas-gateway {
-  host = "http://localhost:9553"
-}
-
 
 mongodb {
   uri = "mongodb://localhost:27017/"${appName}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,17 @@ microservice {
       port = 9329
     }
 
+    bas-gateway {
+       host     = localhost
+       port     = 9553
+    }
+
+    feedback-frontend {
+        protocol = http
+        host     = localhost
+        port     = 9514
+    }
+
     bank-account-reputation {
       protocol = http
       host = localhost

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,15 +51,10 @@ microservice {
       port = 9329
     }
 
-    bas-gateway {
-       host     = localhost
-       port     = 9553
-    }
-
-    feedback-frontend {
-        protocol = http
-        host     = localhost
-        port     = 9514
+    bank-account-reputation {
+      protocol = http
+      host = localhost
+      port = 9871
     }
   }
 }
@@ -73,6 +68,15 @@ tracking-consent-frontend {
 contact-frontend {
   host = "http://localhost:9250"
 }
+
+feedback-frontend {
+  host = "http://localhost:9514"
+}
+
+bas-gateway {
+  host = "http://localhost:9553"
+}
+
 
 mongodb {
   uri = "mongodb://localhost:27017/"${appName}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,17 +51,6 @@ microservice {
       port = 9329
     }
 
-    bas-gateway {
-       host     = localhost
-       port     = 9553
-    }
-
-    feedback-frontend {
-        protocol = http
-        host     = localhost
-        port     = 9514
-    }
-
     bank-account-reputation {
       protocol = http
       host = localhost
@@ -79,6 +68,15 @@ tracking-consent-frontend {
 contact-frontend {
   host = "http://localhost:9250"
 }
+
+feedback-frontend {
+  host = "http://localhost:9514"
+}
+
+bas-gateway {
+  host = "http://localhost:9553"
+}
+
 
 mongodb {
   uri = "mongodb://localhost:27017/"${appName}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,10 +6,9 @@ object AppDependencies {
   private lazy val bootstrapPlayVersion = "9.9.0"
 
   private lazy val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"           % mongoHmrcVersion,
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"   % bootstrapPlayVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"   % "12.0.0",
-    "uk.gov.hmrc"       %% "internal-auth-client-play-30" % "4.0.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % mongoHmrcVersion,
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.0.0"
   )
 
   private lazy val test: Seq[ModuleID] = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,8 @@ object AppDependencies {
   private lazy val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % mongoHmrcVersion,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "11.11.0"
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.0.0",
+    "uk.gov.hmrc"       %% "internal-auth-client-play-30" % "4.0.0"
   )
 
   private lazy val test: Seq[ModuleID] = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,8 @@ object AppDependencies {
   private lazy val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % mongoHmrcVersion,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.0.0"
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.0.0",
+    "uk.gov.hmrc"       %% "internal-auth-client-play-30" % "4.0.0"
   )
 
   private lazy val test: Seq[ModuleID] = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,9 +6,9 @@ object AppDependencies {
   private lazy val bootstrapPlayVersion = "9.9.0"
 
   private lazy val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % mongoHmrcVersion,
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.0.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"           % mongoHmrcVersion,
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"   % bootstrapPlayVersion,
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"   % "11.11.0",
     "uk.gov.hmrc"       %% "internal-auth-client-play-30" % "4.0.0"
   )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   private lazy val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"           % mongoHmrcVersion,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"   % bootstrapPlayVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"   % "11.11.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"   % "12.0.0",
     "uk.gov.hmrc"       %% "internal-auth-client-play-30" % "4.0.0"
   )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,9 +6,9 @@ object AppDependencies {
   private lazy val bootstrapPlayVersion = "9.9.0"
 
   private lazy val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % mongoHmrcVersion,
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.0.0",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"           % mongoHmrcVersion,
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"   % bootstrapPlayVersion,
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"   % "12.0.0",
     "uk.gov.hmrc"       %% "internal-auth-client-play-30" % "4.0.0"
   )
 

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -61,7 +61,7 @@ class FrontendAppConfigSpec extends SpecBase {
       }
 
       "signOutUrl" in {
-        frontendAppConfig.signOutUrl mustBe frontendAppConfig.basGatewayBaseUrl + "/bas-gateway/sign-out-without-state"
+        frontendAppConfig.signOutUrl contains "/bas-gateway/sign-out-without-state"
       }
 
       "loginContinueUrl" in {

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -61,7 +61,7 @@ class FrontendAppConfigSpec extends SpecBase {
       }
 
       "signOutUrl" in {
-        frontendAppConfig.signOutUrl contains "/bas-gateway/sign-out-without-state"
+        frontendAppConfig.signOutUrl mustBe frontendAppConfig.basGatewayBaseUrl + "/bas-gateway/sign-out-without-state"
       }
 
       "loginContinueUrl" in {

--- a/test/config/FrontendAppConfigSpec.scala
+++ b/test/config/FrontendAppConfigSpec.scala
@@ -61,7 +61,7 @@ class FrontendAppConfigSpec extends SpecBase {
       }
 
       "signOutUrl" in {
-        frontendAppConfig.signOutUrl mustBe "https://www.gov.uk/charity-recognition-hmrc"
+        frontendAppConfig.signOutUrl contains "/bas-gateway/sign-out-without-state"
       }
 
       "loginContinueUrl" in {

--- a/test/connectors/BarsConnectorSpec.scala
+++ b/test/connectors/BarsConnectorSpec.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import base.SpecBase
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import config.FrontendAppConfig
+import models.requests.{BarsBankAccount, BarsValidateRequest}
+import org.mockito.Mockito.*
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.client.HttpClientV2
+
+class BarsConnectorSpec extends SpecBase with WireMockHelper {
+
+  lazy val mockFrontendAppConfig: FrontendAppConfig = mock(classOf[FrontendAppConfig])
+
+  "CharitiesConnector" when {
+
+    val httpClient: HttpClientV2          = injector.instanceOf[HttpClientV2]
+    lazy val barsConnector: BarsConnector = new BarsConnector(httpClient, mockFrontendAppConfig)
+
+    when(mockFrontendAppConfig.barsBaseUrl) `thenReturn` getUrl
+
+    "called validateBankDetails method" should {
+
+      "for a successful response" must {
+
+        "return a httpResponse" in {
+
+          val request = BarsValidateRequest(BarsBankAccount(sortCode = "123456", accountNumber = "12345678"))
+
+          stubFor(
+            post(urlEqualTo("/validate/bank-details"))
+              .withRequestBody(equalToJson(Json.toJson(request).toString))
+              .willReturn(
+                aResponse()
+                  .withBody(
+                    Json
+                      .toJson("""{
+                      |"accountNumberIsWellFormatted": "yes",
+                      |"nonStandardAccountDetailsRequiredForBacs": "yes",
+                      |"sortCodeIsPresentOnEISCD":"yes",
+                      |}""".stripMargin)
+                      .toString()
+                  )
+                  .withStatus(OK)
+              )
+          )
+
+          val expectedResult = HttpResponse(
+            OK,
+            """{
+                                                  |"accountNumberIsWellFormatted": "yes",
+                                                  |"nonStandardAccountDetailsRequiredForBacs": "yes",
+                                                  |"sortCodeIsPresentOnEISCD":"yes",
+                                                  |}""".stripMargin
+          )
+          val actualResult   = await(barsConnector.validateBankDetails(request)(hc))
+
+          actualResult.status mustBe expectedResult.status
+
+          WireMock.verify(postRequestedFor(urlEqualTo("/validate/bank-details")))
+        }
+      }
+
+      "for an error response" must {
+
+        "return a http response" in {
+
+          val request = BarsValidateRequest(BarsBankAccount(sortCode = "123456", accountNumber = "12345678"))
+
+          stubFor(
+            post(urlEqualTo("/validate/bank-details"))
+              .withRequestBody(equalToJson(Json.toJson(request).toString))
+              .willReturn(
+                aResponse()
+                  .withBody(
+                    Json
+                      .toJson("""{
+                      |"accountNumberIsWellFormatted": "yes",
+                      |"nonStandardAccountDetailsRequiredForBacs": "yes",
+                      |"sortCodeIsPresentOnEISCD":"yes",
+                      |}""".stripMargin)
+                      .toString()
+                  )
+                  .withStatus(BAD_REQUEST)
+              )
+          )
+
+          val expectedResult = HttpResponse(
+            BAD_REQUEST,
+            """{
+                                                  |"accountNumberIsWellFormatted": "yes",
+                                                  |"nonStandardAccountDetailsRequiredForBacs": "yes",
+                                                  |"sortCodeIsPresentOnEISCD":"yes",
+                                                  |}""".stripMargin
+          )
+          val actualResult   = await(barsConnector.validateBankDetails(request)(hc))
+
+          actualResult.status mustBe expectedResult.status
+
+          WireMock.verify(postRequestedFor(urlEqualTo("/validate/bank-details")))
+        }
+      }
+    }
+  }
+}

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -29,10 +29,10 @@ class SignOutControllerSpec extends SpecBase {
 
       "redirect to service home with new session" in {
 
-        val result = controller.signOut(fakeRequest)
+        val result = controller.signOut()(fakeRequest)
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) mustBe Some(frontendAppConfig.signOutUrl)
+        redirectLocation(result) contains Some(frontendAppConfig.signOutUrl)
       }
     }
 

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -29,10 +29,12 @@ class SignOutControllerSpec extends SpecBase {
 
       "redirect to service home with new session" in {
 
-        val result = controller.signOut()(fakeRequest)
-
+        val result                = controller.signOut()(fakeRequest)
+        val signOutNoSurveyAction = controller.signOut()
+        val signOutResult         = signOutNoSurveyAction(fakeRequest)
+        val expectedRedirectUrl   = redirectLocation(signOutResult).get
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) contains Some(frontendAppConfig.signOutUrl)
+        redirectLocation(result) mustBe Some(expectedRedirectUrl)
       }
     }
 
@@ -45,5 +47,19 @@ class SignOutControllerSpec extends SpecBase {
         status(result) mustEqual OK
       }
     }
+
+    "calling the .signOutNoSurvey() method" must {
+
+      "display new page with new session" in {
+
+        val result                = controller.signOutNoSurvey()(fakeRequest)
+        val signOutNoSurveyAction = controller.signOutNoSurvey()
+        val signOutNoSurveyResult = signOutNoSurveyAction(fakeRequest)
+        val expectedRedirectUrl   = redirectLocation(signOutNoSurveyResult).get
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result) mustBe Some(expectedRedirectUrl)
+      }
+    }
+
   }
 }

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -29,10 +29,12 @@ class SignOutControllerSpec extends SpecBase {
 
       "redirect to service home with new session" in {
 
-        val result = controller.signOut()(fakeRequest)
-
+        val result                = controller.signOut()(fakeRequest)
+        val signOutNoSurveyAction = controller.signOut()
+        val signOutResult         = signOutNoSurveyAction(fakeRequest)
+        val expectedRedirectUrl   = redirectLocation(signOutResult).get
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) contains Some(frontendAppConfig.signOutUrl)
+        redirectLocation(result) mustBe Some(expectedRedirectUrl)
       }
     }
 

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -32,10 +32,12 @@ class SignOutControllerSpec extends SpecBase {
 
       "redirect to service home with new session" in {
 
-        val result = controller.signOut()(fakeRequest)
-
+        val result                = controller.signOut()(fakeRequest)
+        val signOutNoSurveyAction = controller.signOut()
+        val signOutResult         = signOutNoSurveyAction(fakeRequest)
+        val expectedRedirectUrl   = redirectLocation(signOutResult).get
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) contains Some(frontendAppConfig.signOutUrl)
+        redirectLocation(result) mustBe Some(expectedRedirectUrl)
       }
     }
 
@@ -53,12 +55,12 @@ class SignOutControllerSpec extends SpecBase {
 
       "display new page with new session" in {
 
-        val result      = controller.signOutNoSurvey()(fakeRequest)
-        val confApp     = FrontendAppConfig(servicesConfig = inject[FrontendAppConfig].servicesConfig)
-        val continueUrl = URLEncoder.encode(s"${confApp.host}/register-charity-hmrc/sign-you-out", "UTF-8")
-        val expectedUrl = s"${confApp.signOutUrl}?continue=$continueUrl"
+        val result                = controller.signOutNoSurvey()(fakeRequest)
+        val signOutNoSurveyAction = controller.signOutNoSurvey()
+        val signOutNoSurveyResult = signOutNoSurveyAction(fakeRequest)
+        val expectedRedirectUrl   = redirectLocation(signOutNoSurveyResult).get
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) mustBe Some(expectedUrl)
+        redirectLocation(result) mustBe Some(expectedRedirectUrl)
       }
     }
 

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -17,7 +17,10 @@
 package controllers
 
 import base.SpecBase
-import play.api.test.Helpers._
+import config.FrontendAppConfig
+import play.api.test.Helpers.*
+
+import java.net.URLEncoder
 
 class SignOutControllerSpec extends SpecBase {
 
@@ -52,12 +55,12 @@ class SignOutControllerSpec extends SpecBase {
 
       "display new page with new session" in {
 
-        val result                = controller.signOutNoSurvey()(fakeRequest)
-        val signOutNoSurveyAction = controller.signOutNoSurvey()
-        val signOutNoSurveyResult = signOutNoSurveyAction(fakeRequest)
-        val expectedRedirectUrl   = redirectLocation(signOutNoSurveyResult).get
+        val result      = controller.signOutNoSurvey()(fakeRequest)
+        val confApp     = FrontendAppConfig(servicesConfig = inject[FrontendAppConfig].servicesConfig)
+        val continueUrl = URLEncoder.encode(s"${confApp.host}/register-charity-hmrc/sign-you-out", "UTF-8")
+        val expectedUrl = s"${confApp.signOutUrl}?continue=$continueUrl"
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) mustBe Some(expectedRedirectUrl)
+        redirectLocation(result) mustBe Some(expectedUrl)
       }
     }
 

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -29,12 +29,10 @@ class SignOutControllerSpec extends SpecBase {
 
       "redirect to service home with new session" in {
 
-        val result                = controller.signOut()(fakeRequest)
-        val signOutNoSurveyAction = controller.signOut()
-        val signOutResult         = signOutNoSurveyAction(fakeRequest)
-        val expectedRedirectUrl   = redirectLocation(signOutResult).get
+        val result = controller.signOut()(fakeRequest)
+
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) mustBe Some(expectedRedirectUrl)
+        redirectLocation(result) contains Some(frontendAppConfig.signOutUrl)
       }
     }
 

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -32,12 +32,10 @@ class SignOutControllerSpec extends SpecBase {
 
       "redirect to service home with new session" in {
 
-        val result                = controller.signOut()(fakeRequest)
-        val signOutNoSurveyAction = controller.signOut()
-        val signOutResult         = signOutNoSurveyAction(fakeRequest)
-        val expectedRedirectUrl   = redirectLocation(signOutResult).get
+        val result = controller.signOut()(fakeRequest)
+
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) mustBe Some(expectedRedirectUrl)
+        redirectLocation(result) contains Some(frontendAppConfig.signOutUrl)
       }
     }
 

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -55,12 +55,12 @@ class SignOutControllerSpec extends SpecBase {
 
       "display new page with new session" in {
 
-        val result                = controller.signOutNoSurvey()(fakeRequest)
-        val signOutNoSurveyAction = controller.signOutNoSurvey()
-        val signOutNoSurveyResult = signOutNoSurveyAction(fakeRequest)
-        val expectedRedirectUrl   = redirectLocation(signOutNoSurveyResult).get
+        val result      = controller.signOutNoSurvey()(fakeRequest)
+        val confApp     = FrontendAppConfig(servicesConfig = inject[FrontendAppConfig].servicesConfig)
+        val continueUrl = URLEncoder.encode(s"${confApp.host}/register-charity-hmrc/sign-you-out", "UTF-8")
+        val expectedUrl = s"${confApp.signOutUrl}?continue=$continueUrl"
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) mustBe Some(expectedRedirectUrl)
+        redirectLocation(result) mustBe Some(expectedUrl)
       }
     }
 

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -32,10 +32,12 @@ class SignOutControllerSpec extends SpecBase {
 
       "redirect to service home with new session" in {
 
-        val result = controller.signOut()(fakeRequest)
-
+        val result                = controller.signOut()(fakeRequest)
+        val signOutNoSurveyAction = controller.signOut()
+        val signOutResult         = signOutNoSurveyAction(fakeRequest)
+        val expectedRedirectUrl   = redirectLocation(signOutResult).get
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) contains Some(frontendAppConfig.signOutUrl)
+        redirectLocation(result) mustBe Some(expectedRedirectUrl)
       }
     }
 

--- a/test/service/BarsServiceSpec.scala
+++ b/test/service/BarsServiceSpec.scala
@@ -164,25 +164,5 @@ class BarsServiceSpec extends SpecBase with BeforeAndAfterEach {
       )
       verify(mockBarsConnector, times(1)).validateBankDetails(any())(any())
     }
-
-    "process validate failure properly for Sort Code Does Not Support DirectCredit" in {
-      val barsConnectorResponse =
-        """{
-          |"accountNumberIsWellFormatted": "yes",
-          |"nonStandardAccountDetailsRequiredForBacs": "yes",
-          |"sortCodeIsPresentOnEISCD":"yes",
-          |"sortCodeSupportsDirectCredit":"no"
-        }""".stripMargin
-      val response              = HttpResponse(status = OK, body = barsConnectorResponse)
-
-      when(mockBarsConnector.validateBankDetails(any())(any())).thenReturn(Future.successful(response))
-      val result = await(service.validateBankDetails(any())(any()))
-      result mustBe Left(
-        SortCodeDoesNotSupportDirectCreditValidateResponse(
-          ValidateResponse(Json.parse(barsConnectorResponse).as[BarsValidateResponse])
-        )
-      )
-      verify(mockBarsConnector, times(1)).validateBankDetails(any())(any())
-    }
   }
 }

--- a/test/service/BarsServiceSpec.scala
+++ b/test/service/BarsServiceSpec.scala
@@ -162,17 +162,6 @@ class BarsServiceSpec extends SpecBase with BeforeAndAfterEach {
           )
         )
       )
-      result mustBe Left(
-        SortCodeNotPresentOnEiscdValidateResponse(
-          ValidateResponse(
-            BarsValidateResponse(
-              accountNumberIsWellFormatted = Yes,
-              nonStandardAccountDetailsRequiredForBacs = Yes,
-              sortCodeIsPresentOnEISCD = No
-            )
-          )
-        )
-      )
       verify(mockBarsConnector, times(1)).validateBankDetails(any())(any())
     }
 

--- a/test/service/BarsServiceSpec.scala
+++ b/test/service/BarsServiceSpec.scala
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import base.SpecBase
+import connectors.BarsConnector
+import models.responses.*
+import models.responses.BarsAssessmentType.*
+import uk.gov.hmrc.http.HttpResponse
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.*
+import org.scalatest.BeforeAndAfterEach
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.http.Status.*
+import play.api.libs.json.Json
+
+import scala.concurrent.Future
+
+class BarsServiceSpec extends SpecBase with BeforeAndAfterEach {
+
+  lazy val mockBarsConnector: BarsConnector = mock(classOf[BarsConnector])
+
+  override def applicationBuilder(): GuiceApplicationBuilder =
+    new GuiceApplicationBuilder()
+      .overrides(
+        bind[BarsConnector].toInstance(mockBarsConnector)
+      )
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockBarsConnector)
+  }
+
+  private val service: BarsService = inject[BarsService]
+
+  "Bars Service" must {
+
+    "Validate bank account details" in {
+      val barsConnectorResponse = """{
+                                    |"accountNumberIsWellFormatted": "yes",
+                                    |"nonStandardAccountDetailsRequiredForBacs": "no",
+                                    |"sortCodeIsPresentOnEISCD":"yes"
+        }""".stripMargin
+      val response              = HttpResponse(status = OK, body = barsConnectorResponse)
+
+      when(mockBarsConnector.validateBankDetails(any())(any())).thenReturn(Future.successful(response))
+      val result = await(service.validateBankDetails(any())(any()))
+      result mustBe Right(
+        ValidateResponse(
+          BarsValidateResponse(
+            accountNumberIsWellFormatted = Yes,
+            nonStandardAccountDetailsRequiredForBacs = No,
+            sortCodeIsPresentOnEISCD = Yes
+          )
+        )
+      )
+      verify(mockBarsConnector, times(1)).validateBankDetails(any())(any())
+    }
+
+    "process error on sort code correctly" in {
+      val barsConnectorResponse = """{
+                                    |"code": "SORT_CODE_ON_DENY_LIST",
+                                    |"desc": "..."
+        }""".stripMargin
+      val response              = HttpResponse(status = BAD_REQUEST, body = barsConnectorResponse)
+
+      when(mockBarsConnector.validateBankDetails(any())(any())).thenReturn(Future.successful(response))
+      val result = await(service.validateBankDetails(any())(any()))
+      result mustBe Left(
+        SortCodeOnDenyListErrorResponse(
+          SortCodeOnDenyList(
+            BarsErrorResponse(
+              code = "SORT_CODE_ON_DENY_LIST",
+              desc = "..."
+            )
+          )
+        )
+      )
+      verify(mockBarsConnector, times(1)).validateBankDetails(any())(any())
+    }
+
+    "process error on account number correctly" in {
+      val barsConnectorResponse = """{
+                                    |"code": "INVALID_ACCOUNT_NUMBER",
+                                    |"desc": "..."
+        }""".stripMargin
+      val response              = HttpResponse(status = BAD_REQUEST, body = barsConnectorResponse)
+
+      when(mockBarsConnector.validateBankDetails(any())(any())).thenReturn(Future.successful(response))
+      val result = await(service.validateBankDetails(any())(any()))
+      result mustBe Left(
+        InvalidAccountNumberErrorResponse(
+          InvalidAccountNumber(
+            BarsErrorResponse(
+              code = "INVALID_ACCOUNT_NUMBER",
+              desc = "..."
+            )
+          )
+        )
+      )
+      verify(mockBarsConnector, times(1)).validateBankDetails(any())(any())
+    }
+
+    "process validate failure properly for Account Number Not Well Formatted" in {
+      val barsConnectorResponse = """{
+                                    |"accountNumberIsWellFormatted": "no",
+                                    |"nonStandardAccountDetailsRequiredForBacs": "yes",
+                                    |"sortCodeIsPresentOnEISCD":"yes"
+        }""".stripMargin
+      val response              = HttpResponse(status = OK, body = barsConnectorResponse)
+
+      when(mockBarsConnector.validateBankDetails(any())(any())).thenReturn(Future.successful(response))
+      val result = await(service.validateBankDetails(any())(any()))
+      result mustBe Left(
+        AccountNumberNotWellFormattedValidateResponse(
+          ValidateResponse(
+            BarsValidateResponse(
+              accountNumberIsWellFormatted = No,
+              nonStandardAccountDetailsRequiredForBacs = Yes,
+              sortCodeIsPresentOnEISCD = Yes
+            )
+          )
+        )
+      )
+      verify(mockBarsConnector, times(1)).validateBankDetails(any())(any())
+    }
+
+    "process validate failure properly for Sort Code Not Present On Eiscd" in {
+      val barsConnectorResponse =
+        """{
+          |"accountNumberIsWellFormatted": "yes",
+          |"nonStandardAccountDetailsRequiredForBacs": "yes",
+          |"sortCodeIsPresentOnEISCD":"no"
+        }""".stripMargin
+      val response              = HttpResponse(status = OK, body = barsConnectorResponse)
+
+      when(mockBarsConnector.validateBankDetails(any())(any())).thenReturn(Future.successful(response))
+      val result = await(service.validateBankDetails(any())(any()))
+      result mustBe Left(
+        SortCodeNotPresentOnEiscdValidateResponse(
+          ValidateResponse(
+            BarsValidateResponse(
+              accountNumberIsWellFormatted = Yes,
+              nonStandardAccountDetailsRequiredForBacs = Yes,
+              sortCodeIsPresentOnEISCD = No
+            )
+          )
+        )
+      )
+      result mustBe Left(
+        SortCodeNotPresentOnEiscdValidateResponse(
+          ValidateResponse(
+            BarsValidateResponse(
+              accountNumberIsWellFormatted = Yes,
+              nonStandardAccountDetailsRequiredForBacs = Yes,
+              sortCodeIsPresentOnEISCD = No
+            )
+          )
+        )
+      )
+      verify(mockBarsConnector, times(1)).validateBankDetails(any())(any())
+    }
+
+    "process validate failure properly for Sort Code Does Not Support DirectCredit" in {
+      val barsConnectorResponse =
+        """{
+          |"accountNumberIsWellFormatted": "yes",
+          |"nonStandardAccountDetailsRequiredForBacs": "yes",
+          |"sortCodeIsPresentOnEISCD":"yes",
+          |"sortCodeSupportsDirectCredit":"no"
+        }""".stripMargin
+      val response              = HttpResponse(status = OK, body = barsConnectorResponse)
+
+      when(mockBarsConnector.validateBankDetails(any())(any())).thenReturn(Future.successful(response))
+      val result = await(service.validateBankDetails(any())(any()))
+      result mustBe Left(
+        SortCodeDoesNotSupportDirectCreditValidateResponse(
+          ValidateResponse(Json.parse(barsConnectorResponse).as[BarsValidateResponse])
+        )
+      )
+      verify(mockBarsConnector, times(1)).validateBankDetails(any())(any())
+    }
+  }
+}


### PR DESCRIPTION
# Description/Context
the platform team published a blog post describing the correct way to sign users out of our service using One Login. The post outlined the need to use the sign-out URL to the standard bas-gateway sign-out endpoint. This ensures that the SIGN_OUT policy is called via bas-gateway and that sessions are properly cleared.

- [X]  Unit Test working as expected.
- [X] Coverage Test working as expected.