### PR TITLE
DLSN-418: Remove organizationId in charities registration

### DIFF
--- a/app/connectors/CharitiesConnector.scala
+++ b/app/connectors/CharitiesConnector.scala
@@ -20,12 +20,12 @@ import config.FrontendAppConfig
 import connectors.httpParsers.CharitiesRegistrationHttpParser.{CharitiesRegistrationResponse, CharitiesRegistrationResponseReads}
 import models.{SaveStatus, UserAnswers}
 import play.api.Logger
-import play.api.http.Status._
-import play.api.libs.json._
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import play.api.http.Status.*
+import play.api.libs.json.*
+import play.api.libs.ws.writeableOf_JsValue
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
-import play.api.libs.ws.writeableOf_JsValue
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,13 +33,13 @@ import scala.concurrent.{ExecutionContext, Future}
 class CharitiesConnector @Inject() (httpClient: HttpClientV2, implicit val appConfig: FrontendAppConfig) {
 
   private val logger = Logger(this.getClass)
-  def registerCharities(registrationJson: JsValue, organizationId: Int)(implicit
+  def registerCharities(registrationJson: JsValue)(implicit
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[CharitiesRegistrationResponse] = {
 
     val charitiesRegistrationUrl: String =
-      s"${appConfig.getCharitiesBackend}/org/$organizationId/submissions/application"
+      s"${appConfig.getCharitiesBackend}/submissions/application"
 
     httpClient
       .post(url"$charitiesRegistrationUrl")

--- a/app/service/CharitiesRegistrationService.scala
+++ b/app/service/CharitiesRegistrationService.scala
@@ -22,15 +22,14 @@ import connectors.httpParsers.UnexpectedFailureException
 import models.requests.DataRequest
 import pages.AcknowledgementReferencePage
 import play.api.Logger
-import play.api.libs.json.Reads._
-import play.api.libs.json._
+import play.api.libs.json.*
+import play.api.libs.json.Reads.*
 import play.api.mvc.Result
 import play.api.mvc.Results.Redirect
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Random
 
 class CharitiesRegistrationService @Inject() (
   auditService: AuditService,
@@ -46,7 +45,7 @@ class CharitiesRegistrationService @Inject() (
   ): Future[Result] =
     request.userAnswers.get(AcknowledgementReferencePage) match {
       case None =>
-        charitiesConnector.registerCharities(convertInputsForModel(requestJson), Random.nextInt()).flatMap {
+        charitiesConnector.registerCharities(convertInputsForModel(requestJson)).flatMap {
           case Right(_) =>
             for {
               _ <- Future.successful(

--- a/it/test/stubs/CharitiesStub.scala
+++ b/it/test/stubs/CharitiesStub.scala
@@ -27,7 +27,7 @@ import java.time.LocalDate
 
 object CharitiesStub extends WireMockMethods {
 
-  private val charitiesRegistration = "^/org/-?([0-9]*)/submissions/application"
+  private val charitiesRegistration = "/submissions/application"
   private val saveUserAnswer        = "/charities-registration/saveUserAnswer/"
   private val getUserAnswer         = "/charities-registration/getUserAnswer/"
 

--- a/test/service/CharitiesRegistrationServiceSpec.scala
+++ b/test/service/CharitiesRegistrationServiceSpec.scala
@@ -81,11 +81,12 @@ class CharitiesRegistrationServiceSpec extends SpecBase with BeforeAndAfterEach 
       val result = service.register(Json.obj(), noEmailPost = false)(dataRequestWithAcknowledgement, hc, ec)
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(controllers.routes.EmailOrPostController.onPageLoad.url)
-
     }
 
     "redirect to the next page after valid registration response and noEmailPost is disabled" in {
-      when(mockCharitiesConnector.registerCharities(any(), any())(any(), any())).thenReturn(
+      when(
+        mockCharitiesConnector.registerCharities(any())(any(), any())
+      ).thenReturn(
         Future.successful(Right(RegistrationResponse("765432")))
       )
 
@@ -95,14 +96,14 @@ class CharitiesRegistrationServiceSpec extends SpecBase with BeforeAndAfterEach 
 
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(controllers.routes.EmailOrPostController.onPageLoad.url)
-      verify(mockCharitiesConnector, times(1)).registerCharities(any(), any())(any(), any())
+      verify(mockCharitiesConnector, times(1)).registerCharities(any())(any(), any())
 
       verify(mockAuditService, times(1)).sendEvent(any())(any(), any())
       verify(mockAuditService, atLeastOnce()).sendEvent(any[SubmissionAuditEvent])(any(), any())
     }
 
     "redirect to the next page after valid registration response noEmailPost is enabled" in {
-      when(mockCharitiesConnector.registerCharities(any(), any())(any(), any())).thenReturn(
+      when(mockCharitiesConnector.registerCharities(any())(any(), any())).thenReturn(
         Future.successful(Right(RegistrationResponse("765432")))
       )
       doNothing().when(mockAuditService).sendEvent(any())(any(), any())
@@ -111,14 +112,14 @@ class CharitiesRegistrationServiceSpec extends SpecBase with BeforeAndAfterEach 
 
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(controllers.routes.RegistrationSentController.onPageLoad.url)
-      verify(mockCharitiesConnector, times(1)).registerCharities(any(), any())(any(), any())
+      verify(mockCharitiesConnector, times(1)).registerCharities(any())(any(), any())
 
       verify(mockAuditService, times(1)).sendEvent(any())(any(), any())
       verify(mockAuditService, atLeastOnce()).sendEvent(any[SubmissionAuditEvent])(any(), any())
     }
 
     "redirect to the technical difficulties page if registration connector failed" in {
-      when(mockCharitiesConnector.registerCharities(any(), any())(any(), any())).thenReturn(
+      when(mockCharitiesConnector.registerCharities(any())(any(), any())).thenReturn(
         Future.successful(Left(RequestNotAccepted))
       )
 
@@ -126,7 +127,7 @@ class CharitiesRegistrationServiceSpec extends SpecBase with BeforeAndAfterEach 
         await(service.register(expectedJsonObject, noEmailPost = false)(fakeDataRequest, hc, ec))
       }
 
-      verify(mockCharitiesConnector, times(1)).registerCharities(any(), any())(any(), any())
+      verify(mockCharitiesConnector, times(1)).registerCharities(any())(any(), any())
       verify(mockAuditService, never()).sendEvent(any())(any(), any())
     }
 


### PR DESCRIPTION
This change acknowledges that organizationId is not being used by the backend, hence the route is being edited.

- Change connector, service and route using organizationId