### PR TITLE
DLSN-533 Charities: Input fields should allow spacing

### DIFF
--- a/app/forms/common/BankDetailsFormProvider.scala
+++ b/app/forms/common/BankDetailsFormProvider.scala
@@ -31,10 +31,19 @@ class BankDetailsFormProvider @Inject() extends Mappings {
   private[common] val maxLengthAccountName = 60
   private[common] val maxLengthRollNumber  = 18
 
-  private def digitsOnlyConstraint(fieldName: String): Constraint[String] = Constraint { input =>
-    if (input.forall(_.isDigit)) Valid
+  private def sortCodeCharactersConstraint(fieldName: String): Constraint[String] = Constraint { input =>
+    if (input.forall(char => char.isDigit || Character.isWhitespace(char) || char == '-')) Valid
     else Invalid(s"$fieldName.error.format")
   }
+
+  private def accountNumberCharactersConstraint(fieldName: String): Constraint[String] = Constraint { input =>
+    if (input.forall(char => char.isDigit || Character.isWhitespace(char))) Valid
+    else Invalid(s"$fieldName.error.format")
+  }
+
+  private def digitsOnly(input: String): String =
+    input.filter(_.isDigit)
+
 
   private def sortCodeLengthConstraint(fieldName: String): Constraint[String] = Constraint { input =>
     if (input.length == 6) Valid
@@ -53,12 +62,12 @@ class BankDetailsFormProvider @Inject() extends Mappings {
           .verifying(maxLength(maxLengthAccountName, s"$messagePrefix.accountName.error.length"))
           .verifying(regexp(validateFieldWithFullStop, s"$messagePrefix.accountName.error.format")),
         "sortCode"      -> text(s"$messagePrefix.sortCode.error.required")
-          .verifying(digitsOnlyConstraint(s"$messagePrefix.sortCode"))
-          .transform[String](_.filter(_.isDigit), identity)
+          .verifying(sortCodeCharactersConstraint(s"$messagePrefix.sortCode"))
+          .transform[String](digitsOnly, identity)
           .verifying(sortCodeLengthConstraint(s"$messagePrefix.sortCode")),
         "accountNumber" -> text(s"$messagePrefix.accountNumber.error.required")
-          .verifying(digitsOnlyConstraint(s"$messagePrefix.accountNumber"))
-          .transform[String](_.filter(_.isDigit), identity)
+          .verifying(accountNumberCharactersConstraint(s"$messagePrefix.accountNumber"))
+          .transform[String](digitsOnly, identity)
           .verifying(accountNumberLengthConstraint(s"$messagePrefix.accountNumber")),
         "rollNumber"    -> optional(
           textWithOneSpace()
@@ -73,12 +82,12 @@ class BankDetailsFormProvider @Inject() extends Mappings {
       mapping(
         "accountName"   -> default(text(), charityName),
         "sortCode"      -> text(s"$messagePrefix.sortCode.error.required")
-          .verifying(digitsOnlyConstraint(s"$messagePrefix.sortCode"))
-          .transform[String](_.filter(_.isDigit), identity)
+          .verifying(sortCodeCharactersConstraint(s"$messagePrefix.sortCode"))
+          .transform[String](digitsOnly, identity)
           .verifying(sortCodeLengthConstraint(s"$messagePrefix.sortCode")),
         "accountNumber" -> text(s"$messagePrefix.accountNumber.error.required")
-          .verifying(digitsOnlyConstraint(s"$messagePrefix.accountNumber"))
-          .transform[String](_.filter(_.isDigit), identity)
+          .verifying(accountNumberCharactersConstraint(s"$messagePrefix.accountNumber"))
+          .transform[String](digitsOnly, identity)
           .verifying(accountNumberLengthConstraint(s"$messagePrefix.accountNumber")),
         "rollNumber"    -> optional(
           textWithOneSpace()

--- a/app/forms/regulatorsAndDocuments/CharityCommissionRegistrationNumberFormProvider.scala
+++ b/app/forms/regulatorsAndDocuments/CharityCommissionRegistrationNumberFormProvider.scala
@@ -18,6 +18,7 @@ package forms.regulatorsAndDocuments
 
 import forms.mappings.Mappings
 import play.api.data.Form
+import play.api.data.validation.{Constraint, Invalid, Valid}
 
 import javax.inject.Inject
 
@@ -25,9 +26,19 @@ class CharityCommissionRegistrationNumberFormProvider @Inject() extends Mappings
 
   private[regulatorsAndDocuments] val validateRegistrationNumber = """^[0-9]{6,7}$"""
 
+  private def registrationNumberCharactersConstraint(fieldName: String): Constraint[String] = Constraint { input =>
+    if (input.forall(char => char.isDigit || Character.isWhitespace(char))) Valid
+    else Invalid(s"$fieldName.error.format")
+  }
+
+  private def digitsOnly(input: String): String =
+    input.filter(_.isDigit)
+
   def apply(): Form[String] =
     Form(
       "registrationNumber" -> text("charityCommissionRegistrationNumber.error.required")
+        .verifying(registrationNumberCharactersConstraint("charityCommissionRegistrationNumber"))
+        .transform[String](digitsOnly, identity)
         .verifying(regexp(validateRegistrationNumber, "charityCommissionRegistrationNumber.error.format"))
     )
 }

--- a/app/forms/regulatorsAndDocuments/NIRegulatorRegNumberFormProvider.scala
+++ b/app/forms/regulatorsAndDocuments/NIRegulatorRegNumberFormProvider.scala
@@ -18,6 +18,7 @@ package forms.regulatorsAndDocuments
 
 import forms.mappings.Mappings
 import play.api.data.Form
+import play.api.data.validation.{Constraint, Invalid, Valid}
 
 import javax.inject.Inject
 
@@ -25,9 +26,19 @@ class NIRegulatorRegNumberFormProvider @Inject() extends Mappings {
 
   private[regulatorsAndDocuments] val validateRegistrationNumberNI = """^[0-9]{6}$"""
 
+  private def registrationNumberCharactersConstraint(fieldName: String): Constraint[String] = Constraint { input =>
+    if (input.forall(char => char.isDigit || Character.isWhitespace(char))) Valid
+    else Invalid(s"$fieldName.error.format")
+  }
+
+  private def digitsOnly(input: String): String =
+    input.filter(_.isDigit)
+
   def apply(): Form[String] =
     Form(
       "nIRegistrationNumber" -> text("nIRegulatorRegNumber.error.required")
+        .verifying(registrationNumberCharactersConstraint("nIRegulatorRegNumber"))
+        .transform[String](digitsOnly, identity)
         .verifying(regexp(validateRegistrationNumberNI, "nIRegulatorRegNumber.error.format"))
     )
 }

--- a/app/forms/regulatorsAndDocuments/ScottishRegulatorRegNumberFormProvider.scala
+++ b/app/forms/regulatorsAndDocuments/ScottishRegulatorRegNumberFormProvider.scala
@@ -18,6 +18,7 @@ package forms.regulatorsAndDocuments
 
 import forms.mappings.Mappings
 import play.api.data.Form
+import play.api.data.validation.{Constraint, Invalid, Valid}
 
 import javax.inject.Inject
 
@@ -25,9 +26,19 @@ class ScottishRegulatorRegNumberFormProvider @Inject() extends Mappings {
 
   private[regulatorsAndDocuments] val validateRegistrationNumber = """^(?i)SC([0-9]{6})$"""
 
+  private def registrationNumberCharactersConstraint(fieldName: String): Constraint[String] = Constraint { input =>
+    if (input.forall(char => char.isLetterOrDigit || Character.isWhitespace(char))) Valid
+    else Invalid(s"$fieldName.error.format")
+  }
+
+  private def removeWhitespace(input: String): String =
+    input.filterNot(Character.isWhitespace)
+
   def apply(): Form[String] =
     Form(
       "registrationNumber" -> text("scottishRegulatorRegNumber.error.required")
+        .verifying(registrationNumberCharactersConstraint("scottishRegulatorRegNumber"))
+        .transform[String](removeWhitespace, identity)
         .verifying(regexp(validateRegistrationNumber, "scottishRegulatorRegNumber.error.format"))
     )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,12 +3,12 @@ import sbt.*
 object AppDependencies {
 
   private lazy val mongoHmrcVersion     = "2.12.0"
-  private lazy val bootstrapPlayVersion = "10.6.0"
+  private lazy val bootstrapPlayVersion = "10.7.0"
 
   private lazy val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"         % mongoHmrcVersion,
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.29.0"
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "12.32.0"
   )
 
   private lazy val test: Seq[ModuleID] = Seq(

--- a/test/forms/common/BankDetailsFormProviderSpec.scala
+++ b/test/forms/common/BankDetailsFormProviderSpec.scala
@@ -27,6 +27,14 @@ class BankDetailsFormProviderSpec extends StringFieldBehaviours {
   private val formProvider: BankDetailsFormProvider = inject[BankDetailsFormProvider]
   private val form: Form[BankDetails]               = formProvider(messagePrefix)
 
+  private def validBankDetailsData(overrides: (String, String)*): Map[String, String] =
+    Map(
+      "accountName"   -> "Account Name",
+      "sortCode"      -> "123456",
+      "accountNumber" -> "12345678",
+      "rollNumber"    -> "Roll 1"
+    ) ++ overrides
+
   ".accountName" must {
 
     val fieldName   = "accountName"
@@ -88,17 +96,21 @@ class BankDetailsFormProviderSpec extends StringFieldBehaviours {
       val result = form.bind(Map(fieldName -> "123456")).apply(fieldName)
       result.value.value mustBe "123456"
     }
-    "bind sort codes in nn-nn-nn format" in {
-      val result = form.bind(Map(fieldName -> "12-34-56")).apply(fieldName)
-      result.value.value mustBe "12-34-56"
+    "normalise sort codes in nn-nn-nn format" in {
+      val result = form.bind(validBankDetailsData(fieldName -> "12-34-56")).get
+      result.sortCode mustBe "123456"
     }
-    "bind sort codes in nn nn nn format" in {
-      val result = form.bind(Map(fieldName -> "12 34 56")).apply(fieldName)
-      result.value.value mustBe "12 34 56"
+    "normalise sort codes in nn nn nn format" in {
+      val result = form.bind(validBankDetailsData(fieldName -> "12 34 56")).get
+      result.sortCode mustBe "123456"
     }
-    "bind sort codes in nn   nn    nn format" in {
-      val result = form.bind(Map(fieldName -> "12   34   56")).apply(fieldName)
-      result.value.value mustBe "12   34   56"
+    "normalise sort codes in nn   nn    nn format" in {
+      val result = form.bind(validBankDetailsData(fieldName -> "12   34   56")).get
+      result.sortCode mustBe "123456"
+    }
+    "normalise sort codes with leading and trailing spaces" in {
+      val result = form.bind(validBankDetailsData(fieldName -> " 12 34 56 ")).get
+      result.sortCode mustBe "123456"
     }
     "not bind sort codes with characters" in {
       val result = form.bind(Map(fieldName -> "abcdef")).apply(fieldName)
@@ -135,17 +147,21 @@ class BankDetailsFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
-    "bind account number with any number of spaces" in {
-      val result = form.bind(Map(fieldName -> "12   34   56")).apply(fieldName)
-      result.value.value mustBe "12   34   56"
+    "normalise account number with any number of spaces" in {
+      val result = form.bind(validBankDetailsData(fieldName -> "12   34   56")).get
+      result.accountNumber mustBe "123456"
+    }
+    "normalise account number with leading and trailing spaces" in {
+      val result = form.bind(validBankDetailsData(fieldName -> " 12 34 56 78 ")).get
+      result.accountNumber mustBe "12345678"
     }
     "not bind strings with characters" in {
       val result = form.bind(Map(fieldName -> "abcdef")).apply(fieldName)
       result.errors must contain(FormError(fieldName, formatErrorKey))
     }
-    "not bind strings with less than 6 digits" in {
+    "not bind strings with less than 6 digits and spaces" in {
       val result = form.bind(Map(fieldName -> "12 34   5")).apply(fieldName)
-      result.errors must contain(FormError(fieldName, formatErrorKey))
+      result.errors must contain(FormError(fieldName, lengthErrorKey))
     }
     "not bind strings with less than 6 digits (all digits)" in {
       val result = form.bind(Map(fieldName -> "12345")).apply(fieldName)
@@ -157,6 +173,10 @@ class BankDetailsFormProviderSpec extends StringFieldBehaviours {
     }
     "not bind strings with more than 8 digits and spaces" in {
       val result = form.bind(Map(fieldName -> "12 34 56 789")).apply(fieldName)
+      result.errors must contain(FormError(fieldName, lengthErrorKey))
+    }
+    "not bind account number with hyphens" in {
+      val result = form.bind(Map(fieldName -> "12-34-56")).apply(fieldName)
       result.errors must contain(FormError(fieldName, formatErrorKey))
     }
   }

--- a/test/forms/regulatorsAndDocuments/CharityCommissionRegistrationNumberFormProviderSpec.scala
+++ b/test/forms/regulatorsAndDocuments/CharityCommissionRegistrationNumberFormProviderSpec.scala
@@ -25,6 +25,9 @@ class CharityCommissionRegistrationNumberFormProviderSpec extends StringFieldBeh
     inject[CharityCommissionRegistrationNumberFormProvider]
   private val form: Form[String]                                            = formProvider()
 
+  private def validRegistrationNumberData(value: String): Map[String, String] =
+    Map("registrationNumber" -> value)
+
   ".registrationNumber" must {
 
     val requiredKey = "charityCommissionRegistrationNumber.error.required"
@@ -47,7 +50,7 @@ class CharityCommissionRegistrationNumberFormProviderSpec extends StringFieldBeh
     behave like fieldWithRegex(
       form,
       fieldName,
-      "invalidRegistrationNumber",
+      "12345",
       FormError(fieldName, invalidKey, Seq(formProvider.validateRegistrationNumber))
     )
   }
@@ -73,6 +76,14 @@ class CharityCommissionRegistrationNumberFormProviderSpec extends StringFieldBeh
       val filled = form.fill(charityCommissionRegistrationNumber)
       filled("registrationNumber").value.value mustBe charityCommissionRegistrationNumber
     }
+
+    "normalise spaces in CharityCommissionRegistrationNumber correctly" in {
+      val details = form
+        .bind(validRegistrationNumberData("12345 6"))
+        .get
+
+      details mustBe "123456"
+    }
   }
 
   "validateRegistrationNumber" must {
@@ -83,7 +94,6 @@ class CharityCommissionRegistrationNumberFormProviderSpec extends StringFieldBeh
     }
 
     "valid for 01632 960" in {
-
       "01632 960" mustNot fullyMatch regex formProvider.validateRegistrationNumber
     }
   }

--- a/test/forms/regulatorsAndDocuments/NIRegulatorRegNumberFormProviderSpec.scala
+++ b/test/forms/regulatorsAndDocuments/NIRegulatorRegNumberFormProviderSpec.scala
@@ -24,6 +24,9 @@ class NIRegulatorRegNumberFormProviderSpec extends StringFieldBehaviours {
   private val formProvider: NIRegulatorRegNumberFormProvider = inject[NIRegulatorRegNumberFormProvider]
   private val form: Form[String]                             = formProvider()
 
+  private def validRegistrationNumberData(value: String): Map[String, String] =
+    Map("nIRegistrationNumber" -> value)
+
   ".nIRegistrationNumber" must {
 
     val fieldName   = "nIRegistrationNumber"
@@ -45,7 +48,7 @@ class NIRegulatorRegNumberFormProviderSpec extends StringFieldBehaviours {
     behave like fieldWithRegex(
       form,
       fieldName,
-      "123456&",
+      "12345",
       FormError(fieldName, invalidKey, Seq(formProvider.validateRegistrationNumberNI))
     )
   }
@@ -71,6 +74,16 @@ class NIRegulatorRegNumberFormProviderSpec extends StringFieldBehaviours {
       val filled = form.fill(nIRegulatorRegNumber)
       filled("nIRegistrationNumber").value.value mustBe nIRegulatorRegNumber
     }
+
+    "normalise spaces in NIRegulatorRegNumber correctly" in {
+      val registrationNumberWithSpaces = nIRegulatorRegNumber.grouped(2).mkString(" ")
+
+      val details = form
+        .bind(validRegistrationNumberData(registrationNumberWithSpaces))
+        .get
+
+      details mustBe nIRegulatorRegNumber
+    }
   }
 
   "validateRegistrationNumberNI" must {
@@ -81,7 +94,6 @@ class NIRegulatorRegNumberFormProviderSpec extends StringFieldBehaviours {
     }
 
     "valid for 01632 960" in {
-
       "01632 960" mustNot fullyMatch regex formProvider.validateRegistrationNumberNI
     }
   }

--- a/test/forms/regulatorsAndDocuments/ScottishRegulatorRegNumberFormProviderSpec.scala
+++ b/test/forms/regulatorsAndDocuments/ScottishRegulatorRegNumberFormProviderSpec.scala
@@ -24,6 +24,9 @@ class ScottishRegulatorRegNumberFormProviderSpec extends StringFieldBehaviours {
   private val formProvider: ScottishRegulatorRegNumberFormProvider = inject[ScottishRegulatorRegNumberFormProvider]
   private val form: Form[String]                                   = formProvider()
 
+  private def validRegistrationNumberData(value: String): Map[String, String] =
+    Map("registrationNumber" -> value)
+
   ".registrationNumber" must {
 
     val fieldName   = "registrationNumber"
@@ -45,7 +48,7 @@ class ScottishRegulatorRegNumberFormProviderSpec extends StringFieldBehaviours {
     behave like fieldWithRegex(
       form,
       fieldName,
-      "123456&",
+      "SC12345",
       FormError(fieldName, invalidKey, Seq(formProvider.validateRegistrationNumber))
     )
   }
@@ -71,6 +74,17 @@ class ScottishRegulatorRegNumberFormProviderSpec extends StringFieldBehaviours {
       val filled = form.fill(scottishRegulatorRegNumber)
       filled("registrationNumber").value.value mustBe scottishRegulatorRegNumber
     }
+
+    "normalise spaces in ScottishRegulatorRegNumber correctly" in {
+      val registrationNumberWithSpaces =
+        scottishRegulatorRegNumber.take(2) + " " + scottishRegulatorRegNumber.drop(2).grouped(2).mkString(" ")
+
+      val details = form
+        .bind(validRegistrationNumberData(registrationNumberWithSpaces))
+        .get
+
+      details mustBe scottishRegulatorRegNumber
+    }
   }
 
   "validateRegistrationNumber" must {
@@ -81,7 +95,6 @@ class ScottishRegulatorRegNumberFormProviderSpec extends StringFieldBehaviours {
     }
 
     "valid for 01632" in {
-
       "01632" mustNot fullyMatch regex formProvider.validateRegistrationNumber
     }
   }


### PR DESCRIPTION
Changes - 

Normalised spaces in bank sort code and account number fields 

- Amended BankDetailsFormProvider.scala
- Amended tests in BankDetailsFormProviderSpec.scala

Normalise spaces in regulator registration fields

- amended CharityCommissionRegistrationNumberFormProvider.scala
- amended NIRegulatorRegNumberFormProvider.scala
- amended ScottishRegulatorRegNumberFormProvider.scala
- amended tests for CharityCommissionRegistrationNumberFormProviderSpec.scala
- amended tests for  NIRegulatorRegNumberFormProviderSpec.scala
- amended tests for ScottishRegulatorRegNumberFormProviderSpec.scala